### PR TITLE
Tweak default build options

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@ In `.\windows\CommonSettings.props` set `CpuOnlyBuild` to `true` and set `UseCuD
 
 ### cuDNN
 Download `cuDNN v3` or `cuDNN v4` [from nVidia website](https://developer.nvidia.com/cudnn).
-Unpack downloaded zip to `CuDnnPath` defined in `.\windows\CommonSettings.props`.
-Alternatively, you can disable cuDNN by setting `UseCuDNN` to `false` in the property file.
+Unpack downloaded zip to %CUDA_PATH% (environment variable set by CUDA installer).
+Alternatively, you can unpack zip to any location and set `CuDnnPath` to point to this location in `.\windows\CommonSettings.props`.
+`CuDnnPath` defined in `.\windows\CommonSettings.props`.
+Also, you can disable cuDNN by setting `UseCuDNN` to `false` in the property file.
 
 ### Python
 To build Caffe Python wrapper set `PythonSupport` to `true` in `.\windows\CommonSettings.props`.
@@ -51,6 +53,11 @@ conda install --yes numpy scipy matplotlib scikit-image pip
 pip install protobuf
 ```
 
+#### Remark
+After you have build solution with Python support, in order to use it you have to either:  
+1) set PythonPath environment variable to point to <caffe_root>\Build\x64\Release\pycaffe  
+or  
+2) cp –r <caffe_root>\Build\x64\Release\pycaffe\caffe $PYTHON_DIR\lib\site-packages  
 ### Build
 Now, you should be able to build `.\windows\Caffe.sln`
 

--- a/windows/CommonSettings.props.example
+++ b/windows/CommonSettings.props.example
@@ -14,25 +14,25 @@
         <CudaDependencies></CudaDependencies>
 
         <!-- Set CUDA architecture suitable for your GPU.
-         Setting proper architecture is important to mimize your run and compile time.
-         Only Kepler (K10, K20, K40, K80,...) and Maxwell (M4, M40, M6, M60, ...) architectures are supported.
-         For Kepler use "compute_35,sm_35".
-         For Maxwell use "compute_52,sm_52".-->
-        <CudaArchitecture>compute_35,sm_35</CudaArchitecture>
-        <!-- <CudaArchitecture>compute_52,sm_52</CudaArchitecture> -->
+         Setting proper architecture is important to mimize your run and compile time. -->
+        <CudaArchitecture>compute_35,sm_35;compute_52,sm_52</CudaArchitecture>
 
         <!-- CuDNN 3 and 4 are supported -->
-        <CuDnnPath>$(SolutionDir)..\..\CaffeCuDnn</CuDnnPath>
+        <CuDnnPath></CuDnnPath>
         <ScriptsDir>$(SolutionDir)\scripts</ScriptsDir>
     </PropertyGroup>
     <PropertyGroup Condition="'$(CpuOnlyBuild)'=='false'">
         <CudaDependencies>cublas.lib;cuda.lib;curand.lib;cudart.lib</CudaDependencies>
     </PropertyGroup>
+
     <PropertyGroup Condition="'$(UseCuDNN)'=='true'">
         <CudaDependencies>cudnn.lib;$(CudaDependencies)</CudaDependencies>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(UseCuDNN)'=='true' And $(CuDnnPath)!=''">
         <LibraryPath>$(CuDnnPath)\cuda\lib\x64;$(LibraryPath)</LibraryPath>
         <IncludePath>$(CuDnnPath)\cuda\include;$(IncludePath)</IncludePath>
     </PropertyGroup>
+
     <PropertyGroup>
         <OutDir>$(BuildDir)\$(Platform)\$(Configuration)\</OutDir>
         <IntDir>$(BuildDir)\Int\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>

--- a/windows/scripts/BinplaceCudaDependencies.cmd
+++ b/windows/scripts/BinplaceCudaDependencies.cmd
@@ -14,8 +14,13 @@ if %IS_CPU_ONLY_BUILD% == true (
     copy /y "%CUDA_TOOLKIT_BIN_DIR%\curand*.dll" "%OUTPUT_DIR%"
 
     if %USE_CUDNN% == true (
-        echo BinplaceCudaDependencies : Copy cunn*.dll to output.
-        copy /y "%CUDNN_PATH%\cuda\bin\cudnn*.dll" "%OUTPUT_DIR%"
+        echo BinplaceCudaDependencies : Copy cudnn*.dll to output.
+
+        if [%CUDNN_PATH%] == [] (
+            copy /y "%CUDA_TOOLKIT_BIN_DIR%\cudnn*.dll" "%OUTPUT_DIR%"
+        ) else (
+            copy /y "%CUDNN_PATH%\cuda\bin\cudnn*.dll" "%OUTPUT_DIR%"
+        )
     ) else (
         echo BinplaceCudaDependencies : cuDNN isn't enabled.
     )

--- a/windows/scripts/PythonPostBuild.cmd
+++ b/windows/scripts/PythonPostBuild.cmd
@@ -6,3 +6,4 @@ echo PythonPostBuild.cmd : copy python generated scripts to output.
 copy /y "%SOLUTION_DIR%..\python\caffe\*.py" "%OUTPUT_DIR%pycaffe\caffe"
 copy /y "%SOLUTION_DIR%..\python\*.py" "%OUTPUT_DIR%pycaffe"
 move /y "%OUTPUT_DIR%_caffe.*" "%OUTPUT_DIR%pycaffe\caffe"
+copy /y "%OUTPUT_DIR%\*.dll" "%OUTPUT_DIR%pycaffe\caffe"


### PR DESCRIPTION
Make compiling Maxwell and Kepler cuda arch default.
Support extrating cuDNN files to CUDA install folder.
Copy caffe dependancies to python output folder.
Adjust README.md