### PR TITLE
Enable -version and __version__ to return current caffe version.

### DIFF
--- a/windows/caffe/caffe.vcxproj
+++ b/windows/caffe/caffe.vcxproj
@@ -56,6 +56,9 @@
     <PostBuildEvent>
       <Command>"$(ScriptsDir)\FixGFlagsNaming.cmd" "$(OutDir)" $(Configuration)</Command>
     </PostBuildEvent>
+    <ClCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions);CAFFE_VERSION=1.0.0-rc3</PreprocessorDefinitions>
+    </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\tools\caffe.cpp" />

--- a/windows/pycaffe/pycaffe.vcxproj
+++ b/windows/pycaffe/pycaffe.vcxproj
@@ -49,6 +49,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <DisableSpecificWarnings>4003</DisableSpecificWarnings>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NDEBUG;%(PreprocessorDefinitions);CAFFE_VERSION=1.0.0-rc3</PreprocessorDefinitions>
     </ClCompile>
     <PreBuildEvent>
       <Command>"$(ScriptsDir)\PythonPreBuild.cmd" "$(SolutionDir)" "$(ProtocDir)" "$(OutDir)"</Command>


### PR DESCRIPTION
DIGITS enables certain enhanced features if it can find CAFFE version.  However, CAFFE for Windows currently returns 'CAFFE_VERSION', rather than 1.0.0-rc3.
Adding preprocessing definition to vcxproj files is one way to return that information during runtime.   