### PR TITLE
 Add C++ layers for DetectNet and include Caffe version

### DIFF
--- a/3rdparty/cub/host/mutex.cuh
+++ b/3rdparty/cub/host/mutex.cuh
@@ -1,0 +1,170 @@
+/******************************************************************************
+ * Copyright (c) 2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2016, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/**
+ * \file
+ * Simple portable mutex
+ */
+
+
+#pragma once
+
+#if __cplusplus > 199711L
+    #include <mutex>
+#else
+    #if defined(_WIN32) || defined(_WIN64)
+        #include <intrin.h>
+        #include <windows.h>
+        #undef small            // Windows is terrible for polluting macro namespace
+
+        /**
+         * Compiler read/write barrier
+         */
+        #pragma intrinsic(_ReadWriteBarrier)
+
+    #endif
+#endif
+
+#include "../util_namespace.cuh"
+
+
+/// Optional outer namespace(s)
+CUB_NS_PREFIX
+
+/// CUB namespace
+namespace cub {
+
+
+/**
+ * Simple portable mutex
+ *   - Wraps std::mutex when compiled with C++11 or newer (supported on all platforms)
+ *   - Uses GNU/Windows spinlock mechanisms for pre C++11 (supported on x86/x64 when compiled with cl.exe or g++)
+ */
+struct Mutex
+{
+#if __cplusplus > 199711L
+
+    std::mutex mtx;
+
+    void Lock()
+    {
+        mtx.lock();
+    }
+
+    void Unlock()
+    {
+        mtx.unlock();
+    }
+
+    void TryLock()
+    {
+        mtx.try_lock();
+    }
+
+#else       //__cplusplus > 199711L
+
+    #if defined(_MSC_VER)
+
+        // Microsoft VC++
+        typedef long Spinlock;
+
+    #else
+
+        // GNU g++
+        typedef int Spinlock;
+
+        /**
+         * Compiler read/write barrier
+         */
+        __forceinline__ void _ReadWriteBarrier()
+        {
+            __sync_synchronize();
+        }
+
+        /**
+         * Atomic exchange
+         */
+        __forceinline__ long _InterlockedExchange(volatile int * const Target, const int Value)
+        {
+            // NOTE: __sync_lock_test_and_set would be an acquire barrier, so we force a full barrier
+            _ReadWriteBarrier();
+            return __sync_lock_test_and_set(Target, Value);
+        }
+
+        /**
+         * Pause instruction to prevent excess processor bus usage
+         */
+        __forceinline__ void YieldProcessor()
+        {
+        #ifndef __arm__
+                asm volatile("pause\n": : :"memory");
+        #endif  // __arm__
+        }
+
+    #endif  // defined(_MSC_VER)
+
+        /// Lock member
+        volatile Spinlock lock;
+
+        /**
+         * Constructor
+         */
+        Mutex() : lock(0) {}
+
+        /**
+         * Return when the specified spinlock has been acquired
+         */
+        __forceinline__ void Lock()
+        {
+            while (1)
+            {
+                if (!_InterlockedExchange(&lock, 1)) return;
+                while (lock) YieldProcessor();
+            }
+        }
+
+
+        /**
+         * Release the specified spinlock
+         */
+        __forceinline__ void Unlock()
+        {
+            _ReadWriteBarrier();
+            lock = 0;
+        }
+
+#endif      // __cplusplus > 199711L
+
+};
+
+
+
+
+}               // CUB namespace
+CUB_NS_POSTFIX  // Optional outer namespace(s)
+

--- a/3rdparty/cub/util_allocator.cuh
+++ b/3rdparty/cub/util_allocator.cuh
@@ -1,0 +1,700 @@
+/******************************************************************************
+ * Copyright (c) 2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2016, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Simple caching allocator for device memory allocations. The allocator is
+ * thread-safe and capable of managing device allocations on multiple devices.
+ ******************************************************************************/
+
+#pragma once
+
+#include "util_namespace.cuh"
+#include "util_debug.cuh"
+
+#include <set>
+#include <map>
+
+#include "host/mutex.cuh"
+#include <math.h>
+
+/// Optional outer namespace(s)
+CUB_NS_PREFIX
+
+/// CUB namespace
+namespace cub {
+
+
+/**
+ * \addtogroup UtilMgmt
+ * @{
+ */
+
+
+/******************************************************************************
+ * CachingDeviceAllocator (host use)
+ ******************************************************************************/
+
+/**
+ * \brief A simple caching allocator for device memory allocations.
+ *
+ * \par Overview
+ * The allocator is thread-safe and stream-safe and is capable of managing cached
+ * device allocations on multiple devices.  It behaves as follows:
+ *
+ * \par
+ * - Allocations from the allocator are associated with an \p active_stream.  Once freed,
+ *   the allocation becomes available immediately for reuse within the \p active_stream
+ *   with which it was associated with during allocation, and it becomes available for
+ *   reuse within other streams when all prior work submitted to \p active_stream has completed.
+ * - Allocations are categorized and cached by bin size.  A new allocation request of
+ *   a given size will only consider cached allocations within the corresponding bin.
+ * - Bin limits progress geometrically in accordance with the growth factor
+ *   \p bin_growth provided during construction.  Unused device allocations within
+ *   a larger bin cache are not reused for allocation requests that categorize to
+ *   smaller bin sizes.
+ * - Allocation requests below (\p bin_growth ^ \p min_bin) are rounded up to
+ *   (\p bin_growth ^ \p min_bin).
+ * - Allocations above (\p bin_growth ^ \p max_bin) are not rounded up to the nearest
+ *   bin and are simply freed when they are deallocated instead of being returned
+ *   to a bin-cache.
+ * - %If the total storage of cached allocations on a given device will exceed
+ *   \p max_cached_bytes, allocations for that device are simply freed when they are
+ *   deallocated instead of being returned to their bin-cache.
+ *
+ * \par
+ * For example, the default-constructed CachingDeviceAllocator is configured with:
+ * - \p bin_growth          = 8
+ * - \p min_bin             = 3
+ * - \p max_bin             = 7
+ * - \p max_cached_bytes    = 6MB - 1B
+ *
+ * \par
+ * which delineates five bin-sizes: 512B, 4KB, 32KB, 256KB, and 2MB
+ * and sets a maximum of 6,291,455 cached bytes per device
+ *
+ */
+struct CachingDeviceAllocator
+{
+
+    //---------------------------------------------------------------------
+    // Constants
+    //---------------------------------------------------------------------
+
+    /// Out-of-bounds bin
+    static const unsigned int INVALID_BIN = (unsigned int) -1;
+
+    /// Invalid size
+    static const size_t INVALID_SIZE = (size_t) -1;
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS    // Do not document
+
+    /// Invalid device ordinal
+    static const int INVALID_DEVICE_ORDINAL = -1;
+
+    //---------------------------------------------------------------------
+    // Type definitions and helper types
+    //---------------------------------------------------------------------
+
+    /**
+     * Descriptor for device memory allocations
+     */
+    struct BlockDescriptor
+    {
+        void*           d_ptr;              // Device pointer
+        size_t          bytes;              // Size of allocation in bytes
+        unsigned int    bin;                // Bin enumeration
+        int             device;             // device ordinal
+        cudaStream_t    associated_stream;  // Associated associated_stream
+        cudaEvent_t     ready_event;        // Signal when associated stream has run to the point at which this block was freed
+
+        // Constructor (suitable for searching maps for a specific block, given its pointer and device)
+        BlockDescriptor(void *d_ptr, int device) :
+            d_ptr(d_ptr),
+            bytes(0),
+            bin(INVALID_BIN),
+            device(device),
+            associated_stream(0),
+            ready_event(0)
+        {}
+
+        // Constructor (suitable for searching maps for a range of suitable blocks, given a device)
+        BlockDescriptor(int device) :
+            d_ptr(NULL),
+            bytes(0),
+            bin(INVALID_BIN),
+            device(device),
+            associated_stream(0),
+            ready_event(0)
+        {}
+
+        // Comparison functor for comparing device pointers
+        static bool PtrCompare(const BlockDescriptor &a, const BlockDescriptor &b)
+        {
+            if (a.device == b.device)
+                return (a.d_ptr < b.d_ptr);
+            else
+                return (a.device < b.device);
+        }
+
+        // Comparison functor for comparing allocation sizes
+        static bool SizeCompare(const BlockDescriptor &a, const BlockDescriptor &b)
+        {
+            if (a.device == b.device)
+                return (a.bytes < b.bytes);
+            else
+                return (a.device < b.device);
+        }
+    };
+
+    /// BlockDescriptor comparator function interface
+    typedef bool (*Compare)(const BlockDescriptor &, const BlockDescriptor &);
+
+    class TotalBytes {
+    public:
+        size_t free;
+        size_t live;
+        TotalBytes() { free = live = 0; }
+    };
+
+    /// Set type for cached blocks (ordered by size)
+    typedef std::multiset<BlockDescriptor, Compare> CachedBlocks;
+
+    /// Set type for live blocks (ordered by ptr)
+    typedef std::multiset<BlockDescriptor, Compare> BusyBlocks;
+
+    /// Map type of device ordinals to the number of cached bytes cached by each device
+    typedef std::map<int, TotalBytes> GpuCachedBytes;
+
+
+    //---------------------------------------------------------------------
+    // Utility functions
+    //---------------------------------------------------------------------
+
+    /**
+     * Integer pow function for unsigned base and exponent
+     */
+    static unsigned int IntPow(
+        unsigned int base,
+        unsigned int exp)
+    {
+        unsigned int retval = 1;
+        while (exp > 0)
+        {
+            if (exp & 1) {
+                retval = retval * base;        // multiply the result by the current base
+            }
+            base = base * base;                // square the base
+            exp = exp >> 1;                    // divide the exponent in half
+        }
+        return retval;
+    }
+
+    /**
+     * Round up to the nearest power-of
+     */
+    static void NearestPowerOf(
+        unsigned int    &power,
+        size_t          &rounded_bytes,
+        unsigned int    base,
+        size_t          value)
+    {
+        power = 0;
+        rounded_bytes = 1;
+        // we don't bother with other bases so far
+        CHECK_EQ(2, base);
+        // See also:
+        // http://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+        // That code is clever but it doesn't give a value of 'power' argument.
+        // Besides that, 'value' is usually a small number.
+        if (value == 0) return;
+        --value;
+        while (value) {
+            value >>= 1;
+            ++power;
+        }
+        rounded_bytes = power > 0 ? (2ULL << (power-1)) : 1;  // 2^power
+    }
+
+    //---------------------------------------------------------------------
+    // Fields
+    //---------------------------------------------------------------------
+
+    cub::Mutex      mutex;              /// Mutex for thread-safety
+
+    unsigned int    bin_growth;         /// Geometric growth factor for bin-sizes
+    unsigned int    min_bin;            /// Minimum bin enumeration
+    unsigned int    max_bin;            /// Maximum bin enumeration
+
+    size_t          min_bin_bytes;      /// Minimum bin size
+    size_t          max_bin_bytes;      /// Maximum bin size
+    size_t          max_cached_bytes;   /// Maximum aggregate cached bytes per device
+
+    const bool      skip_cleanup;       /// Whether or not to skip a call to FreeAllCached() when destructor is called.  (The CUDA runtime may have already shut down for statically declared allocators)
+    bool            debug;              /// Whether or not to print (de)allocation events to stdout
+
+    GpuCachedBytes  cached_bytes;       /// Map of device ordinal to aggregate cached bytes on that device
+    CachedBlocks    cached_blocks;      /// Set of cached device allocations available for reuse
+    BusyBlocks      live_blocks;        /// Set of live device allocations currently in use
+
+#endif // DOXYGEN_SHOULD_SKIP_THIS
+
+    //---------------------------------------------------------------------
+    // Methods
+    //---------------------------------------------------------------------
+
+    /**
+     * \brief Constructor.
+     */
+    CachingDeviceAllocator(
+        unsigned int    bin_growth,                             ///< Geometric growth factor for bin-sizes
+        unsigned int    min_bin             = 1,                ///< Minimum bin (default is bin_growth ^ 1)
+        unsigned int    max_bin             = INVALID_BIN,      ///< Maximum bin (default is no max bin)
+        size_t          max_cached_bytes    = INVALID_SIZE,     ///< Maximum aggregate cached bytes per device (default is no limit)
+        bool            skip_cleanup        = false,            ///< Whether or not to skip a call to \p FreeAllCached() when the destructor is called (default is to deallocate)
+        bool            debug               = false)            ///< Whether or not to print (de)allocation events to stdout (default is no stderr output)
+    :
+        bin_growth(bin_growth),
+        min_bin(min_bin),
+        max_bin(max_bin),
+        min_bin_bytes(IntPow(bin_growth, min_bin)),
+        max_bin_bytes(IntPow(bin_growth, max_bin)),
+        max_cached_bytes(max_cached_bytes),
+        skip_cleanup(skip_cleanup),
+        debug(debug),
+        cached_blocks(BlockDescriptor::SizeCompare),
+        live_blocks(BlockDescriptor::PtrCompare)
+    {}
+
+
+    /**
+     * \brief Default constructor.
+     *
+     * Configured with:
+     * \par
+     * - \p bin_growth          = 8
+     * - \p min_bin             = 3
+     * - \p max_bin             = 7
+     * - \p max_cached_bytes    = (\p bin_growth ^ \p max_bin) * 3) - 1 = 6,291,455 bytes
+     *
+     * which delineates five bin-sizes: 512B, 4KB, 32KB, 256KB, and 2MB and
+     * sets a maximum of 6,291,455 cached bytes per device
+     */
+    CachingDeviceAllocator(
+        bool skip_cleanup = false,
+        bool debug = false)
+    :
+        bin_growth(8),
+        min_bin(3),
+        max_bin(7),
+        min_bin_bytes(IntPow(bin_growth, min_bin)),
+        max_bin_bytes(IntPow(bin_growth, max_bin)),
+        max_cached_bytes((max_bin_bytes * 3) - 1),
+        skip_cleanup(skip_cleanup),
+        debug(debug),
+        cached_blocks(BlockDescriptor::SizeCompare),
+        live_blocks(BlockDescriptor::PtrCompare)
+    {}
+
+
+    /**
+     * \brief Sets the limit on the number bytes this allocator is allowed to cache per device.
+     *
+     * Changing the ceiling of cached bytes does not cause any allocations (in-use or
+     * cached-in-reserve) to be freed.  See \p FreeAllCached().
+     */
+    cudaError_t SetMaxCachedBytes(
+        size_t max_cached_bytes)
+    {
+        // Lock
+        mutex.Lock();
+
+        if (debug) _CubLog("Changing max_cached_bytes (%lld -> %lld)\n", (long long) this->max_cached_bytes, (long long) max_cached_bytes);
+
+        this->max_cached_bytes = max_cached_bytes;
+
+        // Unlock
+        mutex.Unlock();
+
+        return cudaSuccess;
+    }
+
+
+    /**
+     * \brief Provides a suitable allocation of device memory for the given size on the specified device.
+     *
+     * Once freed, the allocation becomes available immediately for reuse within the \p active_stream
+     * with which it was associated with during allocation, and it becomes available for reuse within other
+     * streams when all prior work submitted to \p active_stream has completed.
+     */
+    cudaError_t DeviceAllocate(
+        int             device,             ///< [in] Device on which to place the allocation
+        void            **d_ptr,            ///< [out] Reference to pointer to the allocation
+        size_t          bytes,              ///< [in] Minimum number of bytes for the allocation
+        cudaStream_t    active_stream = 0)  ///< [in] The stream to be associated with this allocation
+    {
+        *d_ptr                          = NULL;
+        int entrypoint_device           = INVALID_DEVICE_ORDINAL;
+        cudaError_t error               = cudaSuccess;
+
+        if (device == INVALID_DEVICE_ORDINAL)
+        {
+            if (CubDebug(error = cudaGetDevice(&entrypoint_device))) return error;
+            device = entrypoint_device;
+        }
+
+        // Create a block descriptor for the requested allocation
+        bool found = false;
+        BlockDescriptor search_key(device);
+        search_key.associated_stream = active_stream;
+        NearestPowerOf(search_key.bin, search_key.bytes, bin_growth, bytes);
+
+        if (search_key.bin > max_bin)
+        {
+            // Bin is greater than our maximum bin: allocate the request
+            // exactly and give out-of-bounds bin.  It will not be cached
+            // for reuse when returned.
+            search_key.bin      = INVALID_BIN;
+            search_key.bytes    = bytes;
+        }
+        else
+        {
+            // Search for a suitable cached allocation: lock
+            mutex.Lock();
+
+            if (search_key.bin < min_bin)
+            {
+                // Bin is less than minimum bin: round up
+                search_key.bin      = min_bin;
+                search_key.bytes    = min_bin_bytes;
+            }
+
+            // Iterate through the range of cached blocks on the same device in the same bin
+            CachedBlocks::iterator block_itr = cached_blocks.lower_bound(search_key);
+            while ((block_itr != cached_blocks.end())
+                    && (block_itr->device == device)
+                    && (block_itr->bin == search_key.bin))
+            {
+                // To prevent races with reusing blocks returned by the host but still
+                // in use by the device, only consider cached blocks that are
+                // either (from the active stream) or (from an idle stream)
+                if ((active_stream == block_itr->associated_stream) ||
+                    (cudaEventQuery(block_itr->ready_event) != cudaErrorNotReady))
+                {
+                    // Reuse existing cache block.  Insert into live blocks.
+                    found = true;
+                    search_key = *block_itr;
+                    search_key.associated_stream = active_stream;
+                    live_blocks.insert(search_key);
+
+                    // Remove from free blocks
+                    cached_blocks.erase(block_itr);
+                    cached_bytes[device].free -= search_key.bytes;
+                    cached_bytes[device].live += search_key.bytes;
+
+                    if (debug) _CubLog("\tDevice %d reused cached block at %p (%lld bytes) for stream %lld (previously associated with stream %lld).\n",
+                        device, search_key.d_ptr, (long long) search_key.bytes, (long long) search_key.associated_stream, (long long)  block_itr->associated_stream);
+
+                    break;
+                }
+                block_itr++;
+            }
+
+            // Done searching: unlock
+            mutex.Unlock();
+        }
+
+        // Allocate the block if necessary
+        if (!found)
+        {
+            // Set runtime's current device to specified device (entrypoint may not be set)
+            if (device != entrypoint_device)
+            {
+                if (CubDebug(error = cudaGetDevice(&entrypoint_device))) return error;
+                if (CubDebug(error = cudaSetDevice(device))) return error;
+            }
+
+            // Attempt to allocate
+            if (CubDebug(error = cudaMalloc(&search_key.d_ptr, search_key.bytes)) == cudaErrorMemoryAllocation)
+            {
+                // The allocation attempt failed: free all cached blocks on device and retry
+                error = cudaSuccess;    // Reset error
+                if (debug) _CubLog("\tDevice %d failed to allocate %lld bytes for stream %lld, retrying after freeing cached allocations",
+                      device, (long long) search_key.bytes, (long long) search_key.associated_stream);
+
+                // Lock
+                mutex.Lock();
+
+                // Iterate the range of free blocks on the same device
+                BlockDescriptor free_key(device);
+                CachedBlocks::iterator block_itr = cached_blocks.lower_bound(free_key);
+
+                while ((block_itr != cached_blocks.end()) && (block_itr->device == device))
+                {
+                    // No need to worry about synchronization with the device: cudaFree is
+                    // blocking and will synchronize across all kernels executing
+                    // on the current device
+
+                    // Free device memory and destroy stream event.
+                    if (CubDebug(error = cudaFree(block_itr->d_ptr))) break;
+                    if (CubDebug(error = cudaEventDestroy(block_itr->ready_event))) break;
+
+                    // Reduce balance and erase entry
+                    cached_bytes[device].free -= block_itr->bytes;
+                    cached_blocks.erase(block_itr);
+
+                    if (debug) _CubLog("\tDevice %d freed %lld bytes.\n\t\t  %lld available blocks cached (%lld bytes), %lld live blocks (%lld bytes) outstanding.\n",
+                        device, (long long) block_itr->bytes, (long long) cached_blocks.size(), (long long) cached_bytes[device].free, (long long) live_blocks.size(), (long long) cached_bytes[device].live);
+
+                    block_itr++;
+                }
+
+                // Unlock
+                mutex.Unlock();
+
+                // Return under error
+                if (error) return error;
+
+                // Try to allocate again
+                if (CubDebug(error = cudaMalloc(&search_key.d_ptr, search_key.bytes))) return error;
+            }
+
+            // Create ready event
+            if (CubDebug(error = cudaEventCreateWithFlags(&search_key.ready_event, cudaEventDisableTiming)))
+                return error;
+
+            // Insert into live blocks
+            mutex.Lock();
+            live_blocks.insert(search_key);
+            cached_bytes[device].live += search_key.bytes;
+            mutex.Unlock();
+
+            if (debug) _CubLog("\tDevice %d allocated new device block at %p (%lld bytes associated with stream %lld).\n",
+                      device, search_key.d_ptr, (long long) search_key.bytes, (long long) search_key.associated_stream);
+
+            // Attempt to revert back to previous device if necessary
+            if ((entrypoint_device != INVALID_DEVICE_ORDINAL) && (entrypoint_device != device))
+            {
+                if (CubDebug(error = cudaSetDevice(entrypoint_device))) return error;
+            }
+        }
+
+        // Copy device pointer to output parameter
+        *d_ptr = search_key.d_ptr;
+
+        if (debug) _CubLog("\t\t%lld available blocks cached (%lld bytes), %lld live blocks outstanding(%lld bytes).\n",
+            (long long) cached_blocks.size(), (long long) cached_bytes[device].free, (long long) live_blocks.size(), (long long) cached_bytes[device].live);
+
+        return error;
+    }
+
+
+    /**
+     * \brief Provides a suitable allocation of device memory for the given size on the current device.
+     *
+     * Once freed, the allocation becomes available immediately for reuse within the \p active_stream
+     * with which it was associated with during allocation, and it becomes available for reuse within other
+     * streams when all prior work submitted to \p active_stream has completed.
+     */
+    cudaError_t DeviceAllocate(
+        void            **d_ptr,            ///< [out] Reference to pointer to the allocation
+        size_t          bytes,              ///< [in] Minimum number of bytes for the allocation
+        cudaStream_t    active_stream = 0)  ///< [in] The stream to be associated with this allocation
+    {
+        return DeviceAllocate(INVALID_DEVICE_ORDINAL, d_ptr, bytes, active_stream);
+    }
+
+
+    /**
+     * \brief Frees a live allocation of device memory on the specified device, returning it to the allocator.
+     *
+     * Once freed, the allocation becomes available immediately for reuse within the \p active_stream
+     * with which it was associated with during allocation, and it becomes available for reuse within other
+     * streams when all prior work submitted to \p active_stream has completed.
+     */
+    cudaError_t DeviceFree(
+        int             device,
+        void*           d_ptr)
+    {
+        int entrypoint_device           = INVALID_DEVICE_ORDINAL;
+        cudaError_t error               = cudaSuccess;
+
+        if (device == INVALID_DEVICE_ORDINAL)
+        {
+            if (CubDebug(error = cudaGetDevice(&entrypoint_device)))
+                return error;
+            device = entrypoint_device;
+        }
+
+        // Lock
+        mutex.Lock();
+
+        // Find corresponding block descriptor
+        bool recached = false;
+        BlockDescriptor search_key(d_ptr, device);
+        BusyBlocks::iterator block_itr = live_blocks.find(search_key);
+        if (block_itr != live_blocks.end())
+        {
+            // Remove from live blocks
+            search_key = *block_itr;
+            live_blocks.erase(block_itr);
+            cached_bytes[device].live -= search_key.bytes;
+
+            // Keep the returned allocation if bin is valid and we won't exceed the max cached threshold
+            if ((search_key.bin != INVALID_BIN) && (cached_bytes[device].free + search_key.bytes <= max_cached_bytes))
+            {
+                // Insert returned allocation into free blocks
+                recached = true;
+                cached_blocks.insert(search_key);
+                cached_bytes[device].free += search_key.bytes;
+
+                if (debug) _CubLog("\tDevice %d returned %lld bytes from associated stream %lld.\n\t\t %lld available blocks cached (%lld bytes), %lld live blocks outstanding. (%lld bytes)\n",
+                    device, (long long) search_key.bytes, (long long) search_key.associated_stream, (long long) cached_blocks.size(),
+                    (long long) cached_bytes[device].free, (long long) live_blocks.size(), (long long) cached_bytes[device].live);
+            }
+        }
+
+        // Unlock
+        mutex.Unlock();
+
+        // First set to specified device (entrypoint may not be set)
+        if (device != entrypoint_device)
+        {
+            if (CubDebug(error = cudaGetDevice(&entrypoint_device))) return error;
+            if (CubDebug(error = cudaSetDevice(device))) return error;
+        }
+
+        if (recached)
+        {
+            // Insert the ready event in the associated stream (must have current device set properly)
+            if (CubDebug(error = cudaEventRecord(search_key.ready_event, search_key.associated_stream))) return error;
+        }
+        else
+        {
+            // Free the allocation from the runtime and cleanup the event.
+            if (CubDebug(error = cudaFree(d_ptr))) return error;
+            if (CubDebug(error = cudaEventDestroy(search_key.ready_event))) return error;
+
+            if (debug) _CubLog("\tDevice %d freed %lld bytes from associated stream %lld.\n\t\t  %lld available blocks cached (%lld bytes), %lld live blocks (%lld bytes) outstanding.\n",
+                device, (long long) search_key.bytes, (long long) search_key.associated_stream, (long long) cached_blocks.size(), (long long) cached_bytes[device].free, (long long) live_blocks.size(), (long long) cached_bytes[device].live);
+        }
+
+        // Reset device
+        if ((entrypoint_device != INVALID_DEVICE_ORDINAL) && (entrypoint_device != device))
+        {
+            if (CubDebug(error = cudaSetDevice(entrypoint_device))) return error;
+        }
+
+        return error;
+    }
+
+
+    /**
+     * \brief Frees a live allocation of device memory on the current device, returning it to the allocator.
+     *
+     * Once freed, the allocation becomes available immediately for reuse within the \p active_stream
+     * with which it was associated with during allocation, and it becomes available for reuse within other
+     * streams when all prior work submitted to \p active_stream has completed.
+     */
+    cudaError_t DeviceFree(
+        void*           d_ptr)
+    {
+        return DeviceFree(INVALID_DEVICE_ORDINAL, d_ptr);
+    }
+
+
+    /**
+     * \brief Frees all cached device allocations on all devices
+     */
+    cudaError_t FreeAllCached()
+    {
+        cudaError_t error         = cudaSuccess;
+        int entrypoint_device     = INVALID_DEVICE_ORDINAL;
+        int current_device        = INVALID_DEVICE_ORDINAL;
+
+        mutex.Lock();
+
+        while (!cached_blocks.empty())
+        {
+            // Get first block
+            CachedBlocks::iterator begin = cached_blocks.begin();
+
+            // Get entry-point device ordinal if necessary
+            if (entrypoint_device == INVALID_DEVICE_ORDINAL)
+            {
+                if (CubDebug(error = cudaGetDevice(&entrypoint_device))) break;
+            }
+
+            // Set current device ordinal if necessary
+            if (begin->device != current_device)
+            {
+                if (CubDebug(error = cudaSetDevice(begin->device))) break;
+                current_device = begin->device;
+            }
+
+            // Free device memory
+            if (CubDebug(error = cudaFree(begin->d_ptr))) break;
+            if (CubDebug(error = cudaEventDestroy(begin->ready_event))) break;
+
+            // Reduce balance and erase entry
+            cached_bytes[current_device].free -= begin->bytes;
+            cached_blocks.erase(begin);
+
+            if (debug) _CubLog("\tDevice %d freed %lld bytes.\n\t\t  %lld available blocks cached (%lld bytes), %lld live blocks (%lld bytes) outstanding.\n",
+                              current_device, (long long) begin->bytes, (long long) cached_blocks.size(), (long long) cached_bytes[current_device].free, (long long) live_blocks.size(), (long long) cached_bytes[current_device].live);
+        }
+
+        mutex.Unlock();
+
+        // Attempt to revert back to entry-point device if necessary
+        if (entrypoint_device != INVALID_DEVICE_ORDINAL)
+        {
+            if (CubDebug(error = cudaSetDevice(entrypoint_device))) return error;
+        }
+
+        return error;
+    }
+
+
+    /**
+     * \brief Destructor
+     */
+    virtual ~CachingDeviceAllocator()
+    {
+        if (!skip_cleanup)
+            FreeAllCached();
+    }
+
+};
+
+
+
+
+/** @} */       // end group UtilMgmt
+
+}               // CUB namespace
+CUB_NS_POSTFIX  // Optional outer namespace(s)

--- a/3rdparty/cub/util_arch.cuh
+++ b/3rdparty/cub/util_arch.cuh
@@ -1,0 +1,129 @@
+/******************************************************************************
+ * Copyright (c) 2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2016, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/**
+ * \file
+ * Static architectural properties by SM version.
+ */
+
+#pragma once
+
+#include "util_namespace.cuh"
+
+/// Optional outer namespace(s)
+CUB_NS_PREFIX
+
+/// CUB namespace
+namespace cub {
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS    // Do not document
+
+
+/// CUB_PTX_ARCH reflects the PTX version targeted by the active compiler pass (or zero during the host pass).
+#ifndef CUB_PTX_ARCH
+    #ifndef __CUDA_ARCH__
+        #define CUB_PTX_ARCH 0
+    #else
+        #define CUB_PTX_ARCH __CUDA_ARCH__
+    #endif
+#endif
+
+
+/// Whether or not the source targeted by the active compiler pass is allowed to  invoke device kernels or methods from the CUDA runtime API.
+#ifndef CUB_RUNTIME_FUNCTION
+    #if !defined(__CUDA_ARCH__) || (__CUDA_ARCH__>= 350 && defined(__CUDACC_RDC__))
+        #define CUB_RUNTIME_ENABLED
+        #define CUB_RUNTIME_FUNCTION __host__ __device__
+    #else
+        #define CUB_RUNTIME_FUNCTION __host__
+    #endif
+#endif
+
+
+/// Number of threads per warp
+#ifndef CUB_LOG_WARP_THREADS
+    #define CUB_LOG_WARP_THREADS(arch)                      \
+        (5)
+    #define CUB_WARP_THREADS(arch)                          \
+        (1 << CUB_LOG_WARP_THREADS(arch))
+
+    #define CUB_PTX_WARP_THREADS        CUB_WARP_THREADS(CUB_PTX_ARCH)
+    #define CUB_PTX_LOG_WARP_THREADS    CUB_LOG_WARP_THREADS(CUB_PTX_ARCH)
+#endif
+
+
+/// Number of smem banks
+#ifndef CUB_LOG_SMEM_BANKS
+    #define CUB_LOG_SMEM_BANKS(arch)                        \
+        ((arch >= 200) ?                                    \
+            (5) :                                           \
+            (4))
+    #define CUB_SMEM_BANKS(arch)                            \
+        (1 << CUB_LOG_SMEM_BANKS(arch))
+
+    #define CUB_PTX_LOG_SMEM_BANKS      CUB_LOG_SMEM_BANKS(CUB_PTX_ARCH)
+    #define CUB_PTX_SMEM_BANKS          CUB_SMEM_BANKS(CUB_PTX_ARCH)
+#endif
+
+
+/// Oversubscription factor
+#ifndef CUB_SUBSCRIPTION_FACTOR
+    #define CUB_SUBSCRIPTION_FACTOR(arch)                   \
+        ((arch >= 300) ?                                    \
+            (5) :                                           \
+            ((arch >= 200) ?                                \
+                (3) :                                       \
+                (10)))
+    #define CUB_PTX_SUBSCRIPTION_FACTOR             CUB_SUBSCRIPTION_FACTOR(CUB_PTX_ARCH)
+#endif
+
+
+/// Prefer padding overhead vs X-way conflicts greater than this threshold
+#ifndef CUB_PREFER_CONFLICT_OVER_PADDING
+    #define CUB_PREFER_CONFLICT_OVER_PADDING(arch)          \
+        ((arch >= 300) ?                                    \
+            (1) :                                           \
+            (4))
+    #define CUB_PTX_PREFER_CONFLICT_OVER_PADDING    CUB_PREFER_CONFLICT_OVER_PADDING(CUB_PTX_ARCH)
+#endif
+
+
+/// Scale the number of warps to keep same amount of "tile" storage as the nominal configuration for 4B data.  Minimum of two warps.
+#define CUB_BLOCK_THREADS(NOMINAL_4B_BLOCK_THREADS, T, PTX_ARCH) \
+    (CUB_MIN(NOMINAL_4B_BLOCK_THREADS, CUB_MAX(3, ((NOMINAL_4B_BLOCK_THREADS / CUB_WARP_THREADS(PTX_ARCH)) * 4) / sizeof(T)) * CUB_WARP_THREADS(PTX_ARCH)))
+
+/// If necessary, scale down number of items per thread to keep the same amount of "tile" storage as the nominal configuration for 4B data.  Minimum 1 item per thread
+#define CUB_ITEMS_PER_THREAD(NOMINAL_4B_ITEMS_PER_THREAD, NOMINAL_4B_BLOCK_THREADS, T, PTX_ARCH) \
+    (CUB_MIN(NOMINAL_4B_ITEMS_PER_THREAD, CUB_MAX(1, (NOMINAL_4B_ITEMS_PER_THREAD * NOMINAL_4B_BLOCK_THREADS * 4 / sizeof(T)) / CUB_BLOCK_THREADS(NOMINAL_4B_BLOCK_THREADS, T, PTX_ARCH))))
+
+
+
+#endif  // Do not document
+
+}               // CUB namespace
+CUB_NS_POSTFIX  // Optional outer namespace(s)

--- a/3rdparty/cub/util_debug.cuh
+++ b/3rdparty/cub/util_debug.cuh
@@ -1,0 +1,121 @@
+/******************************************************************************
+ * Copyright (c) 2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2016, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/**
+ * \file
+ * Error and event logging routines.
+ *
+ * The following macros definitions are supported:
+ * - \p CUB_LOG.  Simple event messages are printed to \p stdout.
+ */
+
+#pragma once
+
+#include <stdio.h>
+#include "util_namespace.cuh"
+#include "util_arch.cuh"
+
+/// Optional outer namespace(s)
+CUB_NS_PREFIX
+
+/// CUB namespace
+namespace cub {
+
+
+/**
+ * \addtogroup UtilMgmt
+ * @{
+ */
+
+
+/// CUB error reporting macro (prints error messages to stderr)
+#if (defined(DEBUG) || defined(_DEBUG)) && !defined(CUB_STDERR)
+    #define CUB_STDERR
+#endif
+
+
+
+/**
+ * \brief %If \p CUB_STDERR is defined and \p error is not \p cudaSuccess, the corresponding error message is printed to \p stderr (or \p stdout in device code) along with the supplied source context.
+ *
+ * \return The CUDA error.
+ */
+__host__ __device__ __forceinline__ cudaError_t Debug(
+    cudaError_t     error,
+    const char*     filename,
+    int             line)
+{
+#ifdef CUB_STDERR
+    if (error)
+    {
+    #if (CUB_PTX_ARCH == 0)
+        fprintf(stderr, "CUDA error %d [%s, %d]: %s\n", error, filename, line, cudaGetErrorString(error));
+        fflush(stderr);
+    #elif (CUB_PTX_ARCH >= 200)
+        printf("CUDA error %d [block (%d,%d,%d) thread (%d,%d,%d), %s, %d]\n", error, blockIdx.z, blockIdx.y, blockIdx.x, threadIdx.z, threadIdx.y, threadIdx.x, filename, line);
+    #endif
+    }
+#endif
+    return error;
+}
+
+
+/**
+ * \brief Debug macro
+ */
+#ifndef CubDebug
+    #define CubDebug(e) cub::Debug((e), __FILE__, __LINE__)
+#endif
+
+
+/**
+ * \brief Debug macro with exit
+ */
+#ifndef CubDebugExit
+    #define CubDebugExit(e) if (cub::Debug((e), __FILE__, __LINE__)) { exit(1); }
+#endif
+
+
+/**
+ * \brief Log macro for printf statements.
+ */
+#if !defined(_CubLog)
+    #if (CUB_PTX_ARCH == 0)
+        #define _CubLog(format, ...) printf(format,__VA_ARGS__);
+    #elif (CUB_PTX_ARCH >= 200)
+        #define _CubLog(format, ...) printf("[block (%d,%d,%d), thread (%d,%d,%d)]: " format, blockIdx.z, blockIdx.y, blockIdx.x, threadIdx.z, threadIdx.y, threadIdx.x, __VA_ARGS__);
+    #endif
+#endif
+
+
+
+
+/** @} */       // end group UtilMgmt
+
+}               // CUB namespace
+CUB_NS_POSTFIX  // Optional outer namespace(s)

--- a/3rdparty/cub/util_namespace.cuh
+++ b/3rdparty/cub/util_namespace.cuh
@@ -1,0 +1,41 @@
+/******************************************************************************
+ * Copyright (c) 2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2016, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/**
+ * \file
+ * Place-holder for prefixing the cub namespace
+ */
+
+#pragma once
+
+// For example:
+//#define CUB_NS_PREFIX namespace thrust{ namespace detail {
+//#define CUB_NS_POSTFIX } }
+
+#define CUB_NS_PREFIX
+#define CUB_NS_POSTFIX

--- a/examples/kitti/detectnet_network.prototxt
+++ b/examples/kitti/detectnet_network.prototxt
@@ -1,0 +1,2548 @@
+# DetectNet network
+
+# Data/Input layers
+name: "DetectNet"
+layer {
+  name: "train_data"
+  type: "Data"
+  top: "data"
+  data_param {
+    backend: LMDB
+    source: "examples/kitti/kitti_train_images.lmdb"
+    batch_size: 10
+  }
+  include: { phase: TRAIN }
+}
+layer {
+  name: "train_label"
+  type: "Data"
+  top: "label"
+  data_param {
+    backend: LMDB
+    source: "examples/kitti/kitti_train_labels.lmdb"
+    batch_size: 10
+  }
+  include: { phase: TRAIN }
+}
+layer {
+  name: "val_data"
+  type: "Data"
+  top: "data"
+  data_param {
+    backend: LMDB
+    source: "examples/kitti/kitti_test_images.lmdb"
+    batch_size: 6
+  }
+  include: { phase: TEST stage: "val" }
+}
+layer {
+  name: "val_label"
+  type: "Data"
+  top: "label"
+  data_param {
+    backend: LMDB
+    source: "examples/kitti/kitti_test_labels.lmdb"
+    batch_size: 6
+  }
+  include: { phase: TEST stage: "val" }
+}
+layer {
+  name: "deploy_data"
+  type: "Input"
+  top: "data"
+  input_param {
+    shape {
+      dim: 1
+      dim: 3
+      dim: 384
+      dim: 1248
+    }
+  }
+  include: { phase: TEST not_stage: "val" }
+}
+
+# Data transformation layers
+layer {
+  name: "train_transform"
+  type: "DetectNetTransformation"
+  bottom: "data"
+  bottom: "label"
+  top: "transformed_data"
+  top: "transformed_label"
+  detectnet_groundtruth_param: {
+    stride: 16
+    scale_cvg: 0.4
+    gridbox_type: GRIDBOX_MIN
+    coverage_type: RECTANGULAR
+    min_cvg_len: 20
+    obj_norm: true
+    image_size_x: 1248
+    image_size_y: 384
+    crop_bboxes: true
+    object_class: { src: 1 dst: 0} # obj class 1 -> cvg index 0
+  }
+   detectnet_augmentation_param: {
+    crop_prob: 1
+    shift_x: 32
+    shift_y: 32
+    flip_prob: 0.5
+    rotation_prob: 0
+    max_rotate_degree: 5
+    scale_prob: 0.4
+    scale_min: 0.8
+    scale_max: 1.2
+    hue_rotation_prob: 0.8
+    hue_rotation: 30
+    desaturation_prob: 0.8
+    desaturation_max: 0.8
+  }
+  transform_param: {
+    mean_value: 127
+  }
+  include: { phase: TRAIN }
+}
+layer {
+  name: "val_transform"
+  type: "DetectNetTransformation"
+  bottom: "data"
+  bottom: "label"
+  top: "transformed_data"
+  top: "transformed_label"
+  detectnet_groundtruth_param: {
+    stride: 16
+    scale_cvg: 0.4
+    gridbox_type: GRIDBOX_MIN
+    coverage_type: RECTANGULAR
+    min_cvg_len: 20
+    obj_norm: true
+    image_size_x: 1248
+    image_size_y: 384
+    crop_bboxes: false
+    object_class: { src: 1 dst: 0} # obj class 1 -> cvg index 0
+  }
+  transform_param: {
+    mean_value: 127
+  }
+  include: { phase: TEST stage: "val" }
+}
+layer {
+  name: "deploy_transform"
+  type: "Power"
+  bottom: "data"
+  top: "transformed_data"
+  power_param {
+    shift: -127
+  }
+  include: { phase: TEST not_stage: "val" }
+}
+
+# Label conversion layers
+layer {
+  name: "slice-label"
+  type: "Slice"
+  bottom: "transformed_label"
+  top: "foreground-label"
+  top: "bbox-label"
+  top: "size-label"
+  top: "obj-label"
+  top: "coverage-label"
+  slice_param {
+    slice_dim: 1
+    slice_point: 1
+    slice_point: 5
+    slice_point: 7
+    slice_point: 8
+  }
+  include { phase: TRAIN }
+  include { phase: TEST stage: "val" }
+}
+layer {
+  name: "coverage-block"
+  type: "Concat"
+  bottom: "foreground-label"
+  bottom: "foreground-label"
+  bottom: "foreground-label"
+  bottom: "foreground-label"
+  top: "coverage-block"
+  concat_param {
+    concat_dim: 1
+  }
+  include { phase: TRAIN }
+  include { phase: TEST stage: "val" }
+}
+layer {
+  name: "size-block"
+  type: "Concat"
+  bottom: "size-label"
+  bottom: "size-label"
+  top: "size-block"
+  concat_param {
+    concat_dim: 1
+  }
+  include { phase: TRAIN }
+  include { phase: TEST stage: "val" }
+}
+layer {
+  name: "obj-block"
+  type: "Concat"
+  bottom: "obj-label"
+  bottom: "obj-label"
+  bottom: "obj-label"
+  bottom: "obj-label"
+  top: "obj-block"
+  concat_param {
+    concat_dim: 1
+  }
+  include { phase: TRAIN }
+  include { phase: TEST stage: "val" }
+}
+layer {
+  name: "bb-label-norm"
+  type: "Eltwise"
+  bottom: "bbox-label"
+  bottom: "size-block"
+  top: "bbox-label-norm"
+  eltwise_param {
+    operation: PROD
+  }
+  include { phase: TRAIN }
+  include { phase: TEST stage: "val" }
+}
+layer {
+  name: "bb-obj-norm"
+  type: "Eltwise"
+  bottom: "bbox-label-norm"
+  bottom: "obj-block"
+  top: "bbox-obj-label-norm"
+  eltwise_param {
+    operation: PROD
+  }
+  include { phase: TRAIN }
+  include { phase: TEST stage: "val" }
+}
+
+######################################################################
+# Start of convolutional network
+######################################################################
+
+layer {
+  name: "conv1/7x7_s2"
+  type: "Convolution"
+  bottom: "transformed_data"
+  top: "conv1/7x7_s2"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 64
+    pad: 3
+    kernel_size: 7
+    stride: 2
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+
+layer {
+  name: "conv1/relu_7x7"
+  type: "ReLU"
+  bottom: "conv1/7x7_s2"
+  top: "conv1/7x7_s2"
+}
+
+layer {
+  name: "pool1/3x3_s2"
+  type: "Pooling"
+  bottom: "conv1/7x7_s2"
+  top: "pool1/3x3_s2"
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 2
+  }
+}
+
+layer {
+  name: "pool1/norm1"
+  type: "LRN"
+  bottom: "pool1/3x3_s2"
+  top: "pool1/norm1"
+  lrn_param {
+    local_size: 5
+    alpha: 0.0001
+    beta: 0.75
+  }
+}
+
+layer {
+  name: "conv2/3x3_reduce"
+  type: "Convolution"
+  bottom: "pool1/norm1"
+  top: "conv2/3x3_reduce"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 64
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+
+layer {
+  name: "conv2/relu_3x3_reduce"
+  type: "ReLU"
+  bottom: "conv2/3x3_reduce"
+  top: "conv2/3x3_reduce"
+}
+
+layer {
+  name: "conv2/3x3"
+  type: "Convolution"
+  bottom: "conv2/3x3_reduce"
+  top: "conv2/3x3"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 192
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+
+layer {
+  name: "conv2/relu_3x3"
+  type: "ReLU"
+  bottom: "conv2/3x3"
+  top: "conv2/3x3"
+}
+
+layer {
+  name: "conv2/norm2"
+  type: "LRN"
+  bottom: "conv2/3x3"
+  top: "conv2/norm2"
+  lrn_param {
+    local_size: 5
+    alpha: 0.0001
+    beta: 0.75
+  }
+}
+
+layer {
+  name: "pool2/3x3_s2"
+  type: "Pooling"
+  bottom: "conv2/norm2"
+  top: "pool2/3x3_s2"
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 2
+  }
+}
+
+layer {
+  name: "inception_3a/1x1"
+  type: "Convolution"
+  bottom: "pool2/3x3_s2"
+  top: "inception_3a/1x1"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 64
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+
+layer {
+  name: "inception_3a/relu_1x1"
+  type: "ReLU"
+  bottom: "inception_3a/1x1"
+  top: "inception_3a/1x1"
+}
+
+layer {
+  name: "inception_3a/3x3_reduce"
+  type: "Convolution"
+  bottom: "pool2/3x3_s2"
+  top: "inception_3a/3x3_reduce"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 96
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.09
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+
+layer {
+  name: "inception_3a/relu_3x3_reduce"
+  type: "ReLU"
+  bottom: "inception_3a/3x3_reduce"
+  top: "inception_3a/3x3_reduce"
+}
+
+layer {
+  name: "inception_3a/3x3"
+  type: "Convolution"
+  bottom: "inception_3a/3x3_reduce"
+  top: "inception_3a/3x3"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 128
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+
+layer {
+  name: "inception_3a/relu_3x3"
+  type: "ReLU"
+  bottom: "inception_3a/3x3"
+  top: "inception_3a/3x3"
+}
+
+layer {
+  name: "inception_3a/5x5_reduce"
+  type: "Convolution"
+  bottom: "pool2/3x3_s2"
+  top: "inception_3a/5x5_reduce"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 16
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.2
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_3a/relu_5x5_reduce"
+  type: "ReLU"
+  bottom: "inception_3a/5x5_reduce"
+  top: "inception_3a/5x5_reduce"
+}
+layer {
+  name: "inception_3a/5x5"
+  type: "Convolution"
+  bottom: "inception_3a/5x5_reduce"
+  top: "inception_3a/5x5"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 32
+    pad: 2
+    kernel_size: 5
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_3a/relu_5x5"
+  type: "ReLU"
+  bottom: "inception_3a/5x5"
+  top: "inception_3a/5x5"
+}
+
+layer {
+  name: "inception_3a/pool"
+  type: "Pooling"
+  bottom: "pool2/3x3_s2"
+  top: "inception_3a/pool"
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 1
+    pad: 1
+  }
+}
+
+layer {
+  name: "inception_3a/pool_proj"
+  type: "Convolution"
+  bottom: "inception_3a/pool"
+  top: "inception_3a/pool_proj"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 32
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_3a/relu_pool_proj"
+  type: "ReLU"
+  bottom: "inception_3a/pool_proj"
+  top: "inception_3a/pool_proj"
+}
+
+layer {
+  name: "inception_3a/output"
+  type: "Concat"
+  bottom: "inception_3a/1x1"
+  bottom: "inception_3a/3x3"
+  bottom: "inception_3a/5x5"
+  bottom: "inception_3a/pool_proj"
+  top: "inception_3a/output"
+}
+
+layer {
+  name: "inception_3b/1x1"
+  type: "Convolution"
+  bottom: "inception_3a/output"
+  top: "inception_3b/1x1"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 128
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+
+layer {
+  name: "inception_3b/relu_1x1"
+  type: "ReLU"
+  bottom: "inception_3b/1x1"
+  top: "inception_3b/1x1"
+}
+
+layer {
+  name: "inception_3b/3x3_reduce"
+  type: "Convolution"
+  bottom: "inception_3a/output"
+  top: "inception_3b/3x3_reduce"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 128
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.09
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_3b/relu_3x3_reduce"
+  type: "ReLU"
+  bottom: "inception_3b/3x3_reduce"
+  top: "inception_3b/3x3_reduce"
+}
+layer {
+  name: "inception_3b/3x3"
+  type: "Convolution"
+  bottom: "inception_3b/3x3_reduce"
+  top: "inception_3b/3x3"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 192
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_3b/relu_3x3"
+  type: "ReLU"
+  bottom: "inception_3b/3x3"
+  top: "inception_3b/3x3"
+}
+
+layer {
+  name: "inception_3b/5x5_reduce"
+  type: "Convolution"
+  bottom: "inception_3a/output"
+  top: "inception_3b/5x5_reduce"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 32
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.2
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_3b/relu_5x5_reduce"
+  type: "ReLU"
+  bottom: "inception_3b/5x5_reduce"
+  top: "inception_3b/5x5_reduce"
+}
+layer {
+  name: "inception_3b/5x5"
+  type: "Convolution"
+  bottom: "inception_3b/5x5_reduce"
+  top: "inception_3b/5x5"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 96
+    pad: 2
+    kernel_size: 5
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_3b/relu_5x5"
+  type: "ReLU"
+  bottom: "inception_3b/5x5"
+  top: "inception_3b/5x5"
+}
+
+layer {
+  name: "inception_3b/pool"
+  type: "Pooling"
+  bottom: "inception_3a/output"
+  top: "inception_3b/pool"
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 1
+    pad: 1
+  }
+}
+layer {
+  name: "inception_3b/pool_proj"
+  type: "Convolution"
+  bottom: "inception_3b/pool"
+  top: "inception_3b/pool_proj"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 64
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_3b/relu_pool_proj"
+  type: "ReLU"
+  bottom: "inception_3b/pool_proj"
+  top: "inception_3b/pool_proj"
+}
+layer {
+  name: "inception_3b/output"
+  type: "Concat"
+  bottom: "inception_3b/1x1"
+  bottom: "inception_3b/3x3"
+  bottom: "inception_3b/5x5"
+  bottom: "inception_3b/pool_proj"
+  top: "inception_3b/output"
+}
+
+layer {
+  name: "pool3/3x3_s2"
+  type: "Pooling"
+  bottom: "inception_3b/output"
+  top: "pool3/3x3_s2"
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 2
+  }
+}
+
+layer {
+  name: "inception_4a/1x1"
+  type: "Convolution"
+  bottom: "pool3/3x3_s2"
+  top: "inception_4a/1x1"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 192
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+
+layer {
+  name: "inception_4a/relu_1x1"
+  type: "ReLU"
+  bottom: "inception_4a/1x1"
+  top: "inception_4a/1x1"
+}
+
+layer {
+  name: "inception_4a/3x3_reduce"
+  type: "Convolution"
+  bottom: "pool3/3x3_s2"
+  top: "inception_4a/3x3_reduce"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 96
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.09
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+
+layer {
+  name: "inception_4a/relu_3x3_reduce"
+  type: "ReLU"
+  bottom: "inception_4a/3x3_reduce"
+  top: "inception_4a/3x3_reduce"
+}
+
+layer {
+  name: "inception_4a/3x3"
+  type: "Convolution"
+  bottom: "inception_4a/3x3_reduce"
+  top: "inception_4a/3x3"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 208
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+
+layer {
+  name: "inception_4a/relu_3x3"
+  type: "ReLU"
+  bottom: "inception_4a/3x3"
+  top: "inception_4a/3x3"
+}
+
+layer {
+  name: "inception_4a/5x5_reduce"
+  type: "Convolution"
+  bottom: "pool3/3x3_s2"
+  top: "inception_4a/5x5_reduce"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 16
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.2
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_4a/relu_5x5_reduce"
+  type: "ReLU"
+  bottom: "inception_4a/5x5_reduce"
+  top: "inception_4a/5x5_reduce"
+}
+layer {
+  name: "inception_4a/5x5"
+  type: "Convolution"
+  bottom: "inception_4a/5x5_reduce"
+  top: "inception_4a/5x5"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 48
+    pad: 2
+    kernel_size: 5
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_4a/relu_5x5"
+  type: "ReLU"
+  bottom: "inception_4a/5x5"
+  top: "inception_4a/5x5"
+}
+layer {
+  name: "inception_4a/pool"
+  type: "Pooling"
+  bottom: "pool3/3x3_s2"
+  top: "inception_4a/pool"
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 1
+    pad: 1
+  }
+}
+layer {
+  name: "inception_4a/pool_proj"
+  type: "Convolution"
+  bottom: "inception_4a/pool"
+  top: "inception_4a/pool_proj"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 64
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_4a/relu_pool_proj"
+  type: "ReLU"
+  bottom: "inception_4a/pool_proj"
+  top: "inception_4a/pool_proj"
+}
+layer {
+  name: "inception_4a/output"
+  type: "Concat"
+  bottom: "inception_4a/1x1"
+  bottom: "inception_4a/3x3"
+  bottom: "inception_4a/5x5"
+  bottom: "inception_4a/pool_proj"
+  top: "inception_4a/output"
+}
+
+layer {
+  name: "inception_4b/1x1"
+  type: "Convolution"
+  bottom: "inception_4a/output"
+  top: "inception_4b/1x1"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 160
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+
+layer {
+  name: "inception_4b/relu_1x1"
+  type: "ReLU"
+  bottom: "inception_4b/1x1"
+  top: "inception_4b/1x1"
+}
+layer {
+  name: "inception_4b/3x3_reduce"
+  type: "Convolution"
+  bottom: "inception_4a/output"
+  top: "inception_4b/3x3_reduce"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 112
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.09
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_4b/relu_3x3_reduce"
+  type: "ReLU"
+  bottom: "inception_4b/3x3_reduce"
+  top: "inception_4b/3x3_reduce"
+}
+layer {
+  name: "inception_4b/3x3"
+  type: "Convolution"
+  bottom: "inception_4b/3x3_reduce"
+  top: "inception_4b/3x3"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 224
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_4b/relu_3x3"
+  type: "ReLU"
+  bottom: "inception_4b/3x3"
+  top: "inception_4b/3x3"
+}
+layer {
+  name: "inception_4b/5x5_reduce"
+  type: "Convolution"
+  bottom: "inception_4a/output"
+  top: "inception_4b/5x5_reduce"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 24
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.2
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_4b/relu_5x5_reduce"
+  type: "ReLU"
+  bottom: "inception_4b/5x5_reduce"
+  top: "inception_4b/5x5_reduce"
+}
+layer {
+  name: "inception_4b/5x5"
+  type: "Convolution"
+  bottom: "inception_4b/5x5_reduce"
+  top: "inception_4b/5x5"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 64
+    pad: 2
+    kernel_size: 5
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_4b/relu_5x5"
+  type: "ReLU"
+  bottom: "inception_4b/5x5"
+  top: "inception_4b/5x5"
+}
+layer {
+  name: "inception_4b/pool"
+  type: "Pooling"
+  bottom: "inception_4a/output"
+  top: "inception_4b/pool"
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 1
+    pad: 1
+  }
+}
+layer {
+  name: "inception_4b/pool_proj"
+  type: "Convolution"
+  bottom: "inception_4b/pool"
+  top: "inception_4b/pool_proj"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 64
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_4b/relu_pool_proj"
+  type: "ReLU"
+  bottom: "inception_4b/pool_proj"
+  top: "inception_4b/pool_proj"
+}
+layer {
+  name: "inception_4b/output"
+  type: "Concat"
+  bottom: "inception_4b/1x1"
+  bottom: "inception_4b/3x3"
+  bottom: "inception_4b/5x5"
+  bottom: "inception_4b/pool_proj"
+  top: "inception_4b/output"
+}
+
+layer {
+  name: "inception_4c/1x1"
+  type: "Convolution"
+  bottom: "inception_4b/output"
+  top: "inception_4c/1x1"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 128
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+
+layer {
+  name: "inception_4c/relu_1x1"
+  type: "ReLU"
+  bottom: "inception_4c/1x1"
+  top: "inception_4c/1x1"
+}
+
+layer {
+  name: "inception_4c/3x3_reduce"
+  type: "Convolution"
+  bottom: "inception_4b/output"
+  top: "inception_4c/3x3_reduce"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 128
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.09
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+
+layer {
+  name: "inception_4c/relu_3x3_reduce"
+  type: "ReLU"
+  bottom: "inception_4c/3x3_reduce"
+  top: "inception_4c/3x3_reduce"
+}
+layer {
+  name: "inception_4c/3x3"
+  type: "Convolution"
+  bottom: "inception_4c/3x3_reduce"
+  top: "inception_4c/3x3"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 256
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_4c/relu_3x3"
+  type: "ReLU"
+  bottom: "inception_4c/3x3"
+  top: "inception_4c/3x3"
+}
+layer {
+  name: "inception_4c/5x5_reduce"
+  type: "Convolution"
+  bottom: "inception_4b/output"
+  top: "inception_4c/5x5_reduce"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 24
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.2
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_4c/relu_5x5_reduce"
+  type: "ReLU"
+  bottom: "inception_4c/5x5_reduce"
+  top: "inception_4c/5x5_reduce"
+}
+layer {
+  name: "inception_4c/5x5"
+  type: "Convolution"
+  bottom: "inception_4c/5x5_reduce"
+  top: "inception_4c/5x5"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 64
+    pad: 2
+    kernel_size: 5
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_4c/relu_5x5"
+  type: "ReLU"
+  bottom: "inception_4c/5x5"
+  top: "inception_4c/5x5"
+}
+layer {
+  name: "inception_4c/pool"
+  type: "Pooling"
+  bottom: "inception_4b/output"
+  top: "inception_4c/pool"
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 1
+    pad: 1
+  }
+}
+layer {
+  name: "inception_4c/pool_proj"
+  type: "Convolution"
+  bottom: "inception_4c/pool"
+  top: "inception_4c/pool_proj"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 64
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_4c/relu_pool_proj"
+  type: "ReLU"
+  bottom: "inception_4c/pool_proj"
+  top: "inception_4c/pool_proj"
+}
+layer {
+  name: "inception_4c/output"
+  type: "Concat"
+  bottom: "inception_4c/1x1"
+  bottom: "inception_4c/3x3"
+  bottom: "inception_4c/5x5"
+  bottom: "inception_4c/pool_proj"
+  top: "inception_4c/output"
+}
+
+layer {
+  name: "inception_4d/1x1"
+  type: "Convolution"
+  bottom: "inception_4c/output"
+  top: "inception_4d/1x1"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 112
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_4d/relu_1x1"
+  type: "ReLU"
+  bottom: "inception_4d/1x1"
+  top: "inception_4d/1x1"
+}
+layer {
+  name: "inception_4d/3x3_reduce"
+  type: "Convolution"
+  bottom: "inception_4c/output"
+  top: "inception_4d/3x3_reduce"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 144
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_4d/relu_3x3_reduce"
+  type: "ReLU"
+  bottom: "inception_4d/3x3_reduce"
+  top: "inception_4d/3x3_reduce"
+}
+layer {
+  name: "inception_4d/3x3"
+  type: "Convolution"
+  bottom: "inception_4d/3x3_reduce"
+  top: "inception_4d/3x3"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 288
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_4d/relu_3x3"
+  type: "ReLU"
+  bottom: "inception_4d/3x3"
+  top: "inception_4d/3x3"
+}
+layer {
+  name: "inception_4d/5x5_reduce"
+  type: "Convolution"
+  bottom: "inception_4c/output"
+  top: "inception_4d/5x5_reduce"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 32
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_4d/relu_5x5_reduce"
+  type: "ReLU"
+  bottom: "inception_4d/5x5_reduce"
+  top: "inception_4d/5x5_reduce"
+}
+layer {
+  name: "inception_4d/5x5"
+  type: "Convolution"
+  bottom: "inception_4d/5x5_reduce"
+  top: "inception_4d/5x5"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 64
+    pad: 2
+    kernel_size: 5
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_4d/relu_5x5"
+  type: "ReLU"
+  bottom: "inception_4d/5x5"
+  top: "inception_4d/5x5"
+}
+layer {
+  name: "inception_4d/pool"
+  type: "Pooling"
+  bottom: "inception_4c/output"
+  top: "inception_4d/pool"
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 1
+    pad: 1
+  }
+}
+layer {
+  name: "inception_4d/pool_proj"
+  type: "Convolution"
+  bottom: "inception_4d/pool"
+  top: "inception_4d/pool_proj"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 64
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_4d/relu_pool_proj"
+  type: "ReLU"
+  bottom: "inception_4d/pool_proj"
+  top: "inception_4d/pool_proj"
+}
+layer {
+  name: "inception_4d/output"
+  type: "Concat"
+  bottom: "inception_4d/1x1"
+  bottom: "inception_4d/3x3"
+  bottom: "inception_4d/5x5"
+  bottom: "inception_4d/pool_proj"
+  top: "inception_4d/output"
+}
+
+layer {
+  name: "inception_4e/1x1"
+  type: "Convolution"
+  bottom: "inception_4d/output"
+  top: "inception_4e/1x1"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 256
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_4e/relu_1x1"
+  type: "ReLU"
+  bottom: "inception_4e/1x1"
+  top: "inception_4e/1x1"
+}
+layer {
+  name: "inception_4e/3x3_reduce"
+  type: "Convolution"
+  bottom: "inception_4d/output"
+  top: "inception_4e/3x3_reduce"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 160
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.09
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_4e/relu_3x3_reduce"
+  type: "ReLU"
+  bottom: "inception_4e/3x3_reduce"
+  top: "inception_4e/3x3_reduce"
+}
+layer {
+  name: "inception_4e/3x3"
+  type: "Convolution"
+  bottom: "inception_4e/3x3_reduce"
+  top: "inception_4e/3x3"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 320
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_4e/relu_3x3"
+  type: "ReLU"
+  bottom: "inception_4e/3x3"
+  top: "inception_4e/3x3"
+}
+layer {
+  name: "inception_4e/5x5_reduce"
+  type: "Convolution"
+  bottom: "inception_4d/output"
+  top: "inception_4e/5x5_reduce"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 32
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.2
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_4e/relu_5x5_reduce"
+  type: "ReLU"
+  bottom: "inception_4e/5x5_reduce"
+  top: "inception_4e/5x5_reduce"
+}
+layer {
+  name: "inception_4e/5x5"
+  type: "Convolution"
+  bottom: "inception_4e/5x5_reduce"
+  top: "inception_4e/5x5"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 128
+    pad: 2
+    kernel_size: 5
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_4e/relu_5x5"
+  type: "ReLU"
+  bottom: "inception_4e/5x5"
+  top: "inception_4e/5x5"
+}
+layer {
+  name: "inception_4e/pool"
+  type: "Pooling"
+  bottom: "inception_4d/output"
+  top: "inception_4e/pool"
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 1
+    pad: 1
+  }
+}
+layer {
+  name: "inception_4e/pool_proj"
+  type: "Convolution"
+  bottom: "inception_4e/pool"
+  top: "inception_4e/pool_proj"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 128
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_4e/relu_pool_proj"
+  type: "ReLU"
+  bottom: "inception_4e/pool_proj"
+  top: "inception_4e/pool_proj"
+}
+layer {
+  name: "inception_4e/output"
+  type: "Concat"
+  bottom: "inception_4e/1x1"
+  bottom: "inception_4e/3x3"
+  bottom: "inception_4e/5x5"
+  bottom: "inception_4e/pool_proj"
+  top: "inception_4e/output"
+}
+
+
+
+layer {
+  name: "inception_5a/1x1"
+  type: "Convolution"
+  bottom: "inception_4e/output"
+  top: "inception_5a/1x1"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 256
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_5a/relu_1x1"
+  type: "ReLU"
+  bottom: "inception_5a/1x1"
+  top: "inception_5a/1x1"
+}
+
+layer {
+  name: "inception_5a/3x3_reduce"
+  type: "Convolution"
+  bottom: "inception_4e/output"
+  top: "inception_5a/3x3_reduce"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 160
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.09
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_5a/relu_3x3_reduce"
+  type: "ReLU"
+  bottom: "inception_5a/3x3_reduce"
+  top: "inception_5a/3x3_reduce"
+}
+
+layer {
+  name: "inception_5a/3x3"
+  type: "Convolution"
+  bottom: "inception_5a/3x3_reduce"
+  top: "inception_5a/3x3"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 320
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_5a/relu_3x3"
+  type: "ReLU"
+  bottom: "inception_5a/3x3"
+  top: "inception_5a/3x3"
+}
+layer {
+  name: "inception_5a/5x5_reduce"
+  type: "Convolution"
+  bottom: "inception_4e/output"
+  top: "inception_5a/5x5_reduce"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 32
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.2
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_5a/relu_5x5_reduce"
+  type: "ReLU"
+  bottom: "inception_5a/5x5_reduce"
+  top: "inception_5a/5x5_reduce"
+}
+layer {
+  name: "inception_5a/5x5"
+  type: "Convolution"
+  bottom: "inception_5a/5x5_reduce"
+  top: "inception_5a/5x5"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 128
+    pad: 2
+    kernel_size: 5
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_5a/relu_5x5"
+  type: "ReLU"
+  bottom: "inception_5a/5x5"
+  top: "inception_5a/5x5"
+}
+layer {
+  name: "inception_5a/pool"
+  type: "Pooling"
+  bottom: "inception_4e/output"
+  top: "inception_5a/pool"
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 1
+    pad: 1
+  }
+}
+layer {
+  name: "inception_5a/pool_proj"
+  type: "Convolution"
+  bottom: "inception_5a/pool"
+  top: "inception_5a/pool_proj"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 128
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_5a/relu_pool_proj"
+  type: "ReLU"
+  bottom: "inception_5a/pool_proj"
+  top: "inception_5a/pool_proj"
+}
+layer {
+  name: "inception_5a/output"
+  type: "Concat"
+  bottom: "inception_5a/1x1"
+  bottom: "inception_5a/3x3"
+  bottom: "inception_5a/5x5"
+  bottom: "inception_5a/pool_proj"
+  top: "inception_5a/output"
+}
+
+layer {
+  name: "inception_5b/1x1"
+  type: "Convolution"
+  bottom: "inception_5a/output"
+  top: "inception_5b/1x1"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 384
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_5b/relu_1x1"
+  type: "ReLU"
+  bottom: "inception_5b/1x1"
+  top: "inception_5b/1x1"
+}
+layer {
+  name: "inception_5b/3x3_reduce"
+  type: "Convolution"
+  bottom: "inception_5a/output"
+  top: "inception_5b/3x3_reduce"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 1
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 192
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_5b/relu_3x3_reduce"
+  type: "ReLU"
+  bottom: "inception_5b/3x3_reduce"
+  top: "inception_5b/3x3_reduce"
+}
+layer {
+  name: "inception_5b/3x3"
+  type: "Convolution"
+  bottom: "inception_5b/3x3_reduce"
+  top: "inception_5b/3x3"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 384
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_5b/relu_3x3"
+  type: "ReLU"
+  bottom: "inception_5b/3x3"
+  top: "inception_5b/3x3"
+}
+layer {
+  name: "inception_5b/5x5_reduce"
+  type: "Convolution"
+  bottom: "inception_5a/output"
+  top: "inception_5b/5x5_reduce"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 48
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_5b/relu_5x5_reduce"
+  type: "ReLU"
+  bottom: "inception_5b/5x5_reduce"
+  top: "inception_5b/5x5_reduce"
+}
+layer {
+  name: "inception_5b/5x5"
+  type: "Convolution"
+  bottom: "inception_5b/5x5_reduce"
+  top: "inception_5b/5x5"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 128
+    pad: 2
+    kernel_size: 5
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_5b/relu_5x5"
+  type: "ReLU"
+  bottom: "inception_5b/5x5"
+  top: "inception_5b/5x5"
+}
+layer {
+  name: "inception_5b/pool"
+  type: "Pooling"
+  bottom: "inception_5a/output"
+  top: "inception_5b/pool"
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 1
+    pad: 1
+  }
+}
+layer {
+  name: "inception_5b/pool_proj"
+  type: "Convolution"
+  bottom: "inception_5b/pool"
+  top: "inception_5b/pool_proj"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 128
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "inception_5b/relu_pool_proj"
+  type: "ReLU"
+  bottom: "inception_5b/pool_proj"
+  top: "inception_5b/pool_proj"
+}
+layer {
+  name: "inception_5b/output"
+  type: "Concat"
+  bottom: "inception_5b/1x1"
+  bottom: "inception_5b/3x3"
+  bottom: "inception_5b/5x5"
+  bottom: "inception_5b/pool_proj"
+  top: "inception_5b/output"
+}
+layer {
+  name: "pool5/drop_s1"
+  type: "Dropout"
+  bottom: "inception_5b/output"
+  top: "pool5/drop_s1"
+  dropout_param {
+    dropout_ratio: 0.4
+  }
+}
+layer {
+  name: "cvg/classifier"
+  type: "Convolution"
+  bottom: "pool5/drop_s1"
+  top: "cvg/classifier"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 1
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.
+    }
+  }
+}
+layer {
+  name: "coverage/sig"
+  type: "Sigmoid"
+  bottom: "cvg/classifier"
+  top: "coverage"
+}
+layer {
+  name: "bbox/regressor"
+  type: "Convolution"
+  bottom: "pool5/drop_s1"
+  top: "bboxes"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 4
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.
+    }
+  }
+}
+
+######################################################################
+# End of convolutional network
+######################################################################
+
+# Convert bboxes
+layer {
+  name: "bbox_mask"
+  type: "Eltwise"
+  bottom: "bboxes"
+  bottom: "coverage-block"
+  top: "bboxes-masked"
+  eltwise_param {
+    operation: PROD
+  }
+  include { phase: TRAIN }
+  include { phase: TEST stage: "val" }
+}
+layer {
+  name: "bbox-norm"
+  type: "Eltwise"
+  bottom: "bboxes-masked"
+  bottom: "size-block"
+  top: "bboxes-masked-norm"
+  eltwise_param {
+    operation: PROD
+  }
+  include { phase: TRAIN }
+  include { phase: TEST stage: "val" }
+}
+layer {
+  name: "bbox-obj-norm"
+  type: "Eltwise"
+  bottom: "bboxes-masked-norm"
+  bottom: "obj-block"
+  top: "bboxes-obj-masked-norm"
+  eltwise_param {
+    operation: PROD
+  }
+  include { phase: TRAIN }
+  include { phase: TEST stage: "val" }
+}
+
+# Loss layers
+layer {
+  name: "bbox_loss"
+  type: "L1Loss"
+  bottom: "bboxes-obj-masked-norm"
+  bottom: "bbox-obj-label-norm"
+  top: "loss_bbox"
+  loss_weight: 2
+  include { phase: TRAIN }
+  include { phase: TEST stage: "val" }
+}
+layer {
+  name: "coverage_loss"
+  type: "EuclideanLoss"
+  bottom: "coverage"
+  bottom: "coverage-label"
+  top: "loss_coverage"
+  include { phase: TRAIN }
+  include { phase: TEST stage: "val" }
+}
+
+# Cluster bboxes
+layer {
+    type: 'Python'
+    name: 'cluster'
+    bottom: 'coverage'
+    bottom: 'bboxes'
+    top: 'bbox-list'
+    python_param {
+        module: 'caffe.layers.detectnet.clustering'
+        layer: 'ClusterDetections'
+        param_str : '1248, 352, 16, 0.6, 3, 0.02, 22'
+    }
+    include: { phase: TEST }
+}
+
+# Calculate mean average precision
+layer {
+  type: 'Python'
+  name: 'cluster_gt'
+  bottom: 'coverage-label'
+  bottom: 'bbox-label'
+  top: 'bbox-list-label'
+  python_param {
+      module: 'caffe.layers.detectnet.clustering'
+      layer: 'ClusterGroundtruth'
+      param_str : '1248, 352, 16'
+  }
+  include: { phase: TEST stage: "val" }
+}
+layer {
+    type: 'Python'
+    name: 'score'
+    bottom: 'bbox-list-label'
+    bottom: 'bbox-list'
+    top: 'bbox-list-scored'
+    python_param {
+        module: 'caffe.layers.detectnet.mean_ap'
+        layer: 'ScoreDetections'
+    }
+    include: { phase: TEST stage: "val" }
+}
+layer {
+    type: 'Python'
+    name: 'mAP'
+    bottom: 'bbox-list-scored'
+    top: 'mAP'
+    top: 'precision'
+    top: 'recall'
+    python_param {
+        module: 'caffe.layers.detectnet.mean_ap'
+        layer: 'mAP'
+        param_str : '1248, 352, 16'
+    }
+    include: { phase: TEST stage: "val" }
+}

--- a/examples/kitti/detectnet_solver.prototxt
+++ b/examples/kitti/detectnet_solver.prototxt
@@ -1,0 +1,21 @@
+# DetectNet solver
+net: "examples/kitti/detectnet_network.prototxt"
+test_state { stage: "val" }
+
+max_iter: 38000 # ~60 train epochs
+test_interval: 1280 # ~2 train epochs
+test_iter: 185 # 1 test epoch
+snapshot: 1280 # ~2 train epochs
+snapshot_prefix: "examples/kitti/detectnet_snapshot"
+display: 160
+
+solver_type: ADAM
+base_lr: 0.0002
+lr_policy: "step"
+stepsize: 12000
+gamma: 0.1
+momentum: 0.9
+momentum2: 0.999
+weight_decay: 1e-08
+
+solver_mode: GPU

--- a/examples/kitti/detectnet_time.sh
+++ b/examples/kitti/detectnet_time.sh
@@ -1,0 +1,1 @@
+build/tools/caffe time -model examples/kitti/detectnet_network.prototxt $@

--- a/examples/kitti/detectnet_train.sh
+++ b/examples/kitti/detectnet_train.sh
@@ -1,0 +1,4 @@
+build/tools/caffe train \
+    -solver examples/kitti/detectnet_solver.prototxt \
+    -weights models/bvlc_googlenet/bvlc_googlenet.caffemodel \
+    $@

--- a/include/caffe/layers/detectnet_transform_layer.hpp
+++ b/include/caffe/layers/detectnet_transform_layer.hpp
@@ -1,0 +1,155 @@
+#ifndef DETECTNET_TRANSFORMATION_HPP
+#define DETECTNET_TRANSFORMATION_HPP
+
+#include <boost/array.hpp>
+
+#include <opencv2/core/core.hpp>
+#include <opencv2/opencv.hpp>
+
+#include <vector>
+
+#include "caffe/blob.hpp"
+#include "caffe/common.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+
+namespace caffe {
+
+template<typename Dtype>
+class CoverageGenerator;
+
+template<typename Dtype>
+struct BboxLabel_;
+
+struct AugmentSelection;
+
+/**
+ * @brief Applies common transformations to the input data, such as
+ * scaling, mirroring, substracting the image mean...
+ */
+template <typename Dtype>
+class DetectNetTransformationLayer : public Layer<Dtype> {
+ public:
+  typedef cv::Size2i Size2i;
+  typedef cv::Size_<Dtype> Size2v;
+  typedef cv::Point2i Point2i;
+  typedef cv::Point_<Dtype> Point2v;
+  typedef cv::Rect Rect;
+  typedef cv::Rect_<Dtype> Rectv;
+  typedef cv::Vec<Dtype, 3> Vec3v;
+  typedef cv::Mat_<cv::Vec<Dtype, 1> > Mat1v;
+  typedef cv::Mat_<Vec3v> Mat3v;
+  typedef BboxLabel_<Dtype> BboxLabel;
+
+  explicit DetectNetTransformationLayer(const LayerParameter& param);
+
+  virtual ~DetectNetTransformationLayer() {}
+
+  virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+
+  virtual inline const char* type() const { return "DetectNetTransformation"; }
+  virtual inline int ExactNumBottomBlobs() const { return 2; }
+  virtual inline int ExactNumTopBlobs() const { return 2; }
+
+ protected:
+  virtual void Forward_cpu(
+      const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+
+
+  virtual void Backward_cpu(
+      const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down,
+      const vector<Blob<Dtype>*>& bottom) {}
+
+  void transform(
+      const Mat3v& inputImage,
+      const vector<BboxLabel>& inputBboxes,
+      Mat3v* outputImage,
+      Dtype* outputLabel);
+
+
+  /**
+   * @return a Dtype from [0..1].
+   */
+  Dtype randDouble();
+
+  bool augmentation_flip(
+      const Mat3v& img,
+      Mat3v* img_aug,
+      const vector<BboxLabel>& bboxlist,
+      vector<BboxLabel>*);
+  float augmentation_rotate(
+      const Mat3v& img_src,
+      Mat3v* img_aug,
+      const vector<BboxLabel>& bboxlist,
+      vector<BboxLabel>*);
+  float augmentation_scale(
+      const Mat3v& img,
+      Mat3v* img_temp,
+      const vector<BboxLabel>& bboxlist,
+      vector<BboxLabel>*);
+  void transform_scale(
+      const Mat3v& img,
+      Mat3v* img_temp,
+      const vector<BboxLabel>& bboxList,
+      vector<BboxLabel>* bboxList_aug,
+      const Size2i& size);
+  Point2i augmentation_crop(
+      const Mat3v& img_temp,
+      Mat3v* img_aug,
+      const vector<BboxLabel>& bboxlist,
+      vector<BboxLabel>*);
+
+  void transform_crop(
+      const Mat3v& img_temp,
+      Mat3v* img_aug,
+      const vector<BboxLabel>& bboxlist,
+      vector<BboxLabel>* bboxlist_aug,
+      Rect inner,
+      Size2i outer_area,
+      Point2i outer_offset) const;
+
+  float augmentation_hueRotation(
+      const Mat3v& img,
+      Mat3v* result);
+
+  float augmentation_desaturation(
+      const Mat3v& img,
+      Mat3v* result);
+
+  Mat1v getTransformationMatrix(Rect region, Dtype rotation) const;
+  Rect getBoundingRect(Rect region, Dtype rotation) const;
+  void matToBlob(const Mat3v& source, Dtype* destination) const;
+  void matsToBlob(const vector<Mat3v>& source, Blob<Dtype>* destination) const;
+  vector<Mat3v> blobToMats(const Blob<Dtype>& image) const;
+  vector<vector<BboxLabel> > blobToLabels(const Blob<Dtype>& labels) const;
+  Mat3v dataToMat(
+      const Dtype* _data,
+      Size2i dimensions) const;
+  void retrieveMeanImage(Size2i dimensions = Size2i());
+  void retrieveMeanChannels();
+
+  void meanSubtract(Mat3v* source) const;
+  void pixelMeanSubtraction(Mat3v* source) const;
+  void channelMeanSubtraction(Mat3v* source) const;
+
+  DetectNetAugmentationParameter a_param_;
+  DetectNetGroundTruthParameter g_param_;
+  TransformationParameter t_param_;
+
+  shared_ptr<CoverageGenerator<Dtype> > coverage_;
+
+  Phase phase_;
+
+  Mat3v data_mean_;
+  boost::array<Dtype, 3> mean_values_;
+  shared_ptr<Caffe::RNG> rng_;
+};
+
+}  // namespace caffe
+
+#endif /* DETECTNET_TRANSFORMATION_HPP */

--- a/include/caffe/layers/l1_loss_layer.hpp
+++ b/include/caffe/layers/l1_loss_layer.hpp
@@ -1,0 +1,51 @@
+#ifndef CAFFE_L1_LOSS_LAYER_HPP_
+#define CAFFE_L1_LOSS_LAYER_HPP_
+
+#include <vector>
+
+#include "caffe/blob.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+
+#include "caffe/layers/loss_layer.hpp"
+
+namespace caffe {
+
+/*
+ * L1Loss
+ */
+template <typename Dtype>
+class L1LossLayer : public LossLayer<Dtype> {
+ public:
+  explicit L1LossLayer(const LayerParameter& param)
+      : LossLayer<Dtype>(param), diff_() {}
+  virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+
+  virtual inline const char* type() const { return "L1Loss"; }
+  /**
+   * Unlike most loss layers, in the L1LossLayer we can backpropagate
+   * to both inputs -- override to return true and always allow force_backward.
+   */
+  virtual inline bool AllowForceBackward(const int bottom_index) const {
+    return true;
+  }
+
+ protected:
+  /// @copydoc L1LossLayer
+  virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+//  virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+//      const vector<Blob<Dtype>*>& top);
+  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+//  virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
+//      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+
+  Blob<Dtype> diff_;
+  Blob<Dtype> sign_;
+};
+
+}  // namespace caffe
+
+#endif  // CAFFE_L1_LOSS_LAYER_HPP_

--- a/include/caffe/util/detectnet_coverage.hpp
+++ b/include/caffe/util/detectnet_coverage.hpp
@@ -1,0 +1,246 @@
+#ifndef DETECTNET_COVERAGE_HPP
+#define DETECTNET_COVERAGE_HPP
+
+#include <boost/ref.hpp>
+
+#include <opencv2/core/core.hpp>
+#include <opencv2/opencv.hpp>
+
+#include <map>
+#include <vector>
+
+#include "caffe/blob.hpp"
+#include "caffe/common.hpp"
+
+namespace caffe {
+
+template<typename Dtype>
+class CoverageGenerator;
+
+template<typename Dtype>
+struct BboxLabel_ {
+  typedef cv::Rect_<Dtype> Rectv;
+  typedef cv::Point3_<Dtype> Point3v;
+
+  // BboxLabel[0]  = boundingbox topleft X (objective)
+  // BboxLabel[1]  = boundingbox topleft Y
+  // BboxLabel[2]  = boundingbox width
+  // BboxLabel[3]  = boundingbox height
+  Rectv bbox;
+  // BboxLabel[4]  = alpha angle (objective)
+  Dtype alpha;
+  // BboxLabel[5]  = class number (objective)
+  Dtype classNumber;
+  // BboxLabel[6]  = bbox.scenario()
+  Dtype scenario;
+  // BboxLabel[7]  = y axis rotation
+  Dtype roty;
+  // BboxLabel[8]  = truncated
+  Dtype truncated;
+  // BboxLabel[9]  = occluded
+  Dtype occlusion;
+  // BboxLabel[10]  = object length
+  // BboxLabel[11]  = object width
+  // BboxLabel[12]  = object height
+  Point3v dimensions;
+  // BboxLabel[13] = location_x
+  // BboxLabel[14] = location_y
+  // BboxLabel[15] = location_z
+  Point3v location;
+};
+
+template <typename Dtype>
+class TransformedLabel_ {
+ public:
+  typedef boost::reference_wrapper<Dtype> reference_wrapper_dtype;
+
+  // foreground:
+  Dtype& foreground;
+  // top left corner:
+  Dtype& topLeft_x;
+  Dtype& topLeft_y;
+  // bottom right corner:
+  Dtype& bottomRight_x;
+  Dtype& bottomRight_y;
+  // inverse size:
+  Dtype& dimension_w;
+  Dtype& dimension_h;
+  // obj_norm:
+  Dtype& obj_norm;
+  // coverage classes:
+  vector<reference_wrapper_dtype> coverages;
+
+  TransformedLabel_(
+      const CoverageGenerator<Dtype>& coverageGenerator,
+      Dtype* transformedLabels,
+      size_t g_x,
+      size_t g_y);
+  virtual ~TransformedLabel_() {}
+};
+
+template <typename Dtype>
+class CoverageRegion_ {
+ public:
+  typedef cv::Rect_<Dtype> Rectv;
+
+  virtual ~CoverageRegion_() {}
+
+  virtual Dtype area() const = 0;
+  virtual Dtype intersectionArea(const Rectv& gridBox) const = 0;
+};
+
+
+template <typename Dtype>
+class CoverageGenerator {
+ public:
+  typedef boost::reference_wrapper<Dtype> reference_wrapper_dtype;
+  typedef cv::Mat3b Mat3b;
+  typedef cv::Point2i Point2i;
+  typedef cv::Point_<Dtype> Point2v;
+  typedef cv::Rect Rect;
+  typedef cv::Rect_<Dtype> Rectv;
+  typedef cv::Scalar Scalar;
+  typedef cv::Size_<Dtype> Size2v;
+  typedef cv::Vec3i Vec3i;
+  typedef BboxLabel_<Dtype> BboxLabel;
+  typedef TransformedLabel_<Dtype> TransformedLabel;
+  typedef CoverageRegion_<Dtype> CoverageRegion;
+  typedef typename vector<reference_wrapper_dtype>::const_iterator
+      coverage_iterator;
+  typedef map<size_t, size_t> LabelMap;
+
+  static const size_t TRANSFORMED_LABEL_SIZE = 8;
+
+  explicit CoverageGenerator(const DetectNetGroundTruthParameter& param);
+  virtual ~CoverageGenerator() {}
+
+  /**
+   * @brief computes gridbox labels from a list of bounding boxes.
+   */
+  virtual void generate(
+      Dtype* transformedLabels,
+      const vector <BboxLabel>& bboxlist) const;
+
+  inline Vec3i dimensions() const {
+    return Vec3i(
+        label_size_,
+        gridROI_.height,
+        gridROI_.width);
+  }
+
+  inline bool validClass(size_t iClass) const {
+    return labels_.count(iClass) > 0;
+  }
+
+  /**
+   * @brief Constructs a CoverageGenerator provided settings passed via a
+   * TransformationParameter object.
+   * @return a pointer to the created object. Caller assumes ownership.
+   */
+  static CoverageGenerator<Dtype>* create(
+      const DetectNetGroundTruthParameter& param);
+
+ protected:
+  /**
+   * @brief Produce a coverage region from a bounding box defining that region.
+   * Coverage region must exist only within the defined bounding box.
+   * @return a pointer to the defined coverage region. Caller assumes ownership.
+   */
+  virtual CoverageRegion* coverageRegion(
+      const Rectv& boundingBox) const = 0;
+
+
+  /**
+   * @brief Converts an image-space bounding box to the proper coverage region
+   * bounding box defined by this object's TransformationParameters.
+   * @param transformedLabels bounds of detection.
+   */
+  virtual Rectv coverageBoundingBox(const Rectv& boundingBox) const;
+
+  /**
+   * @return the inverse of the area of a given coverage region, in gridspace.
+   */
+  virtual Dtype objectNormValue(
+      const CoverageRegion& coverageRegion) const;
+
+  /**
+   * @brief Zeroes all data represented by this gridbox array.
+   */
+  virtual void clearLabel(Dtype* transformedLabels) const;
+
+  /**
+   * @brief transforms an imagespace rectangle into a gridspace rectangle,
+   * ensuring that the gridspace rectangle is always larger than its
+   * corresponding imagespace rectangle.
+   */
+  virtual Rect imageRectToGridRect(const Rectv& area) const;
+
+  /**
+   * @brief Retrieves a gridbox label specification at the given x and y
+   * coordinates.
+   *
+   * @param x x-coord
+   * @param y y-coord
+   */
+  TransformedLabel transformedLabelAt(
+      Dtype* transformedLabels,
+      size_t x,
+      size_t y) const;
+
+  Scalar bboxToColor(const Point2i& tl, const Point2i& br) const;
+
+  LabelMap assignLabels(
+      const DetectNetGroundTruthParameter& g_param_) const;
+
+  size_t findNumLabels(const LabelMap& labels) const;
+
+  vector<BboxLabel> pruneBboxes(const vector<BboxLabel>& labels) const;
+
+  const DetectNetGroundTruthParameter param_;
+  const Rectv imageROI_;
+  const Rect gridROI_;
+  const Dtype gridBoxArea_;
+  const Dtype minObjNorm_;
+  const LabelMap labels_;
+  const size_t label_size_;
+
+  friend class TransformedLabel_<Dtype>;
+};
+
+
+template <typename Dtype>
+class RectangularCoverageRegion: public CoverageRegion_<Dtype> {
+ public:
+  typedef cv::Rect_<Dtype> Rectv;
+
+  explicit RectangularCoverageRegion(const Rectv& _region) : region(_region) {}
+
+  virtual Dtype area() const { return region.area(); }
+  virtual Dtype intersectionArea(const Rectv& gridBox) const {
+    return (region & gridBox).area();
+  }
+ protected:
+  Rectv region;
+};
+
+
+template <typename Dtype>
+class RectangularCoverageGenerator: public CoverageGenerator<Dtype> {
+ public:
+  typedef cv::Rect_<Dtype> Rectv;
+
+  explicit RectangularCoverageGenerator(
+      const DetectNetGroundTruthParameter& param)
+  : CoverageGenerator<Dtype>(param)
+  { }
+
+ protected:
+  virtual CoverageRegion_<Dtype>* coverageRegion(
+      const Rectv& boundingBox) const {
+    return new RectangularCoverageRegion<Dtype>(boundingBox);
+  }
+};
+
+}  // namespace caffe
+
+#endif /* DETECTNET_COVERAGE_HPP */

--- a/include/caffe/util/gpu_memory.hpp
+++ b/include/caffe/util/gpu_memory.hpp
@@ -1,0 +1,195 @@
+#ifndef CAFFE_UTIL_GPU_MEMORY_HPP_
+#define CAFFE_UTIL_GPU_MEMORY_HPP_
+
+#include <vector>
+#include "caffe/common.hpp"
+#ifndef CPU_ONLY
+
+namespace cub {
+  class CachingDeviceAllocator;
+}
+
+namespace caffe {
+
+struct GPUMemory {
+  static void GetInfo(size_t* free_mem, size_t* used_mem) {
+    return mgr_.GetInfo(free_mem, used_mem);
+  }
+
+  static cudaStream_t device_stream(int device) {
+    return mgr_.device_stream(device);
+  }
+
+  template <class Any>
+  static void allocate(Any** ptr, size_t size, int device,
+      cudaStream_t stream) {
+    if (!try_allocate(reinterpret_cast<void**>(ptr), size, device, stream)) {
+      LOG(FATAL) << "Out of memory: failed to allocate " << size
+          << " bytes on device " << device;
+    }
+  }
+
+  static void deallocate(void* ptr, int device, cudaStream_t stream) {
+    mgr_.deallocate(ptr, device, stream);
+  }
+
+  static bool try_allocate(void** ptr, size_t size, int device,
+      cudaStream_t stream) {
+    return mgr_.try_allocate(ptr, size, device, stream);
+  }
+
+  enum Mode {
+    CUDA_MALLOC,   // Straight CUDA malloc/free (may be expensive)
+    CUB_ALLOCATOR  // CUB caching allocator
+  };
+
+  // Scope initializes global Memory Manager for a given scope.
+  // It's instantiated in test(), train() and time() Caffe brewing functions
+  // as well as in unit tests main().
+  struct Scope {
+    Scope(const std::vector<int>& gpus, Mode m = CUB_ALLOCATOR,
+          bool debug = false) {
+      mgr_.init(gpus, m, debug);
+    }
+  };
+
+  // Workspace's release() functionality depends on global pool availability
+  // If pool is available, it returns memory to the pool and sets ptr to NULL
+  // If pool is not available, it retains memory.
+  // This is single GPU workspace. See MultiWorkspace for multi-GPU support.
+  struct Workspace {
+    Workspace()
+      : ptr_(NULL), size_(0), device_(INVALID_DEVICE),
+        stream_(cudaStreamDefault) {}
+    ~Workspace() { mgr_.deallocate(ptr_, device_, stream_); }
+
+    void* data() const {
+      CHECK_NOTNULL(ptr_);
+      return ptr_;
+    }
+    size_t size() const { return size_; }
+    int device() const { return device_; }
+
+    bool try_reserve(size_t size, int device, cudaStream_t stream) {
+      bool status = true;
+      if (size > size_ || ptr_ == NULL) {
+        if (ptr_ != NULL) {
+          mgr_.deallocate(ptr_, device_, stream_);
+        }
+        if (device != INVALID_DEVICE) {
+          device_ = device;  // switch from default to specific one
+        }
+        status = mgr_.try_allocate(&ptr_, size, device_, stream);
+        if (status) {
+          CHECK_NOTNULL(ptr_);
+          size_ = size;
+          stream_ = stream;
+        }
+      }
+      return status;
+    }
+
+    void reserve(size_t size, int device, cudaStream_t stream) {
+      if (!try_reserve(size, device, stream)) {
+        LOG(FATAL) << "Out of memory: failed to allocate " << size
+            << " bytes on device " << device;
+      }
+    }
+
+    void release() {
+      if (mgr_.using_pool() && ptr_ != NULL) {
+        mgr_.deallocate(ptr_, device_, stream_);
+        ptr_ = NULL;
+        size_ = 0;
+      }
+      // otherwise (no pool) - we retain memory in the buffer
+    }
+
+   private:
+    void* ptr_;
+    size_t size_;
+    int device_;
+    cudaStream_t stream_;
+
+    DISABLE_COPY_AND_ASSIGN(Workspace);
+  };
+
+  // This implementation maintains workspaces on per-GPU basis.
+  struct MultiWorkspace {
+    bool try_reserve(size_t size) {
+      const int device = current_device();
+      cudaStream_t stream = device_stream(device);
+      return current_workspace(device)->try_reserve(size, device, stream);
+    }
+    void reserve(size_t size) {
+      const int device = current_device();
+      cudaStream_t stream = device_stream(device);
+      current_workspace(device)->reserve(size, device, stream);
+    }
+    void release() {
+      current_workspace(current_device())->release();
+    }
+    void* data() const {
+      return current_workspace(current_device())->data();
+    }
+    size_t size() const {
+      return current_workspace(current_device())->size();
+    }
+
+   private:
+    shared_ptr<Workspace> current_workspace(int device) const;
+    mutable vector<shared_ptr<Workspace> > workspaces_;
+  };
+
+ private:
+  struct Manager {
+    Manager();
+    ~Manager();
+    void lazy_init(int device);
+    void GetInfo(size_t* free_mem, size_t* used_mem);
+    void deallocate(void* ptr, int device, cudaStream_t stream);
+    bool try_allocate(void** ptr, size_t size, int device, cudaStream_t);
+    const char* pool_name() const;
+    bool using_pool() const { return mode_ != CUDA_MALLOC; }
+    void init(const std::vector<int>&, Mode, bool);
+    cudaStream_t device_stream(int device);
+
+    Mode mode_;
+    bool debug_;
+
+   private:
+    struct DevInfo {
+      DevInfo() {
+        free_ = total_ = flush_count_ = 0;
+      }
+      size_t free_;
+      size_t total_;
+      unsigned flush_count_;
+    };
+    void update_dev_info(int device);
+    vector<DevInfo> dev_info_;
+    bool initialized_;
+    cub::CachingDeviceAllocator* cub_allocator_;
+    vector<cudaStream_t> device_streams_;
+
+    static const unsigned int BIN_GROWTH;  ///< Geometric growth factor
+    static const unsigned int MIN_BIN;  ///< Minimum bin
+    static const unsigned int MAX_BIN;  ///< Maximum bin
+    static const size_t MAX_CACHED_BYTES;  ///< Maximum aggregate cached bytes
+  };
+
+  static Manager mgr_;
+  static const int INVALID_DEVICE;  ///< Default is invalid: CUB takes care
+
+  static int current_device() {
+    int device;
+    CUDA_CHECK(cudaGetDevice(&device));
+    return device;
+  }
+};
+
+}  // namespace caffe
+
+#endif
+
+#endif

--- a/python/caffe/layers/detectnet/clustering.py
+++ b/python/caffe/layers/detectnet/clustering.py
@@ -1,0 +1,214 @@
+import math
+
+import cv2 as cv
+import numpy as np
+
+import caffe
+
+MAX_BOXES = 50
+
+
+class ClusterGroundtruth(caffe.Layer):
+    """
+    * converts ground truth labels from grid format to list
+    * bottom[0] - coverage-label
+        [ batch_size x grid_sz_x x grid_sz_y x 1 ]
+    * bottom[1] - bbox-label
+        [batch_size x grid_sz_x x grid_sz_y x 4 (xl, yt, xr, yb)]
+    * top [0] - list of groundtruth bbox
+        [ batch_size x max_bbox_per_image x 5 (xl, yt, xr, yb, 0)]
+
+    Example prototxt definition:
+
+    layer {
+        type: 'Python'
+        name: 'cluster_gt'
+        # gt_bbox_list is a batch_size x MAX_BOXES x 5 blob
+        top: 'gt_bbox_list'
+        bottom: 'coverage-label'
+        bottom: 'bbox-label'
+        python_param {
+            module: 'caffe.layers.detectnet.clustering'
+            layer: 'ClusterGroundtruth'
+            # parameters - img_size_x, img_size_y, stride,
+            param_str : '1248,352,16'
+        }
+        include: { phase: TEST }
+    }
+    """
+
+    def setup(self, bottom, top):
+        self.is_groundtruth = True
+        try:
+            plist = self.param_str.split(',')
+            self.image_size_x = int(plist[0])
+            self.image_size_y = int(plist[1])
+            self.stride = int(plist[2])
+        except ValueError:
+            raise ValueError("Parameter string missing or data type is wrong!")
+
+    def reshape(self, bottom, top):
+        n_images = bottom[0].data.shape[0]
+        # Assuming that max booxes per image are MAX_BOXES
+        top[0].reshape(n_images, MAX_BOXES, 5)
+
+    def forward(self, bottom, top):
+        bbox = cluster(self, bottom[0].data, bottom[1].data)
+        top[0].data[...] = bbox
+
+    def backward(self, top, propagate_down, bottom):
+        pass
+
+
+class ClusterDetections(caffe.Layer):
+    """
+    * convert network output in grid format to list using group rectangles clustering
+    * bottom[0] - predicted coverage
+        [ batch_size x grid_sz_x x grid_sz_y x 1 ]
+    * bottom[1] - predicted bbox
+        [batch_size x grid_sz_x x grid_sz_y x 4 (xl, yt, xr, yb)]
+    * top [0] - list of predicted bbox
+        [ batch_size x max_bbox_per_image x 5 (xl, yt, xr, yb, confidence) ]
+
+    Example prototxt definition:
+
+    layer {
+        type: 'Python'
+        name: 'cluster'
+        # det_bbox_list is a batch_size x MAX_BOXES x 5 blob
+        top: 'det_bbox_list'
+        bottom: 'coverage'
+        bottom: 'bbox/regressor'
+        python_param {
+            module: 'caffe.layers.detectnet.clustering'
+            layer: 'ClusterDetections'
+            # parameters - img_size_x, img_size_y, stride,
+            # gridbox_cvg_threshold,gridbox_rect_threshold,gridbox_rect_eps,min_height
+            param_str : '1248,352,16,0.05,1,0.025,22'
+        }
+        include: { phase: TEST }
+    }
+    """
+
+    def setup(self, bottom, top):
+        self.is_groundtruth = False
+        try:
+            plist = self.param_str.split(',')
+            self.image_size_x = int(plist[0])
+            self.image_size_y = int(plist[1])
+            self.stride = int(plist[2])
+            self.gridbox_cvg_threshold = float(plist[3])
+            self.gridbox_rect_thresh = int(plist[4])
+            self.gridbox_rect_eps = float(plist[5])
+            self.min_height = int(plist[6])
+        except ValueError:
+            raise ValueError("Parameter string missing or data type is wrong!")
+
+    def reshape(self, bottom, top):
+        n_images = bottom[0].data.shape[0]
+        # Assuming that max booxes per image are MAX_BOXES
+        top[0].reshape(n_images, MAX_BOXES, 5)
+
+    def forward(self, bottom, top):
+        bbox = cluster(self, bottom[0].data, bottom[1].data)
+        top[0].data[...] = bbox
+
+    def backward(self, top, propagate_down, bottom):
+        pass
+
+
+def gridbox_to_boxes(net_cvg, net_boxes, self):
+    im_sz_x = self.image_size_x
+    im_sz_y = self.image_size_y
+    stride = self.stride
+
+    grid_sz_x = int(im_sz_x / stride)
+    grid_sz_y = int(im_sz_y / stride)
+
+    boxes = []
+    cvgs = []
+
+    cell_width = im_sz_x / grid_sz_x
+    cell_height = im_sz_y / grid_sz_y
+
+    cvg_val = net_cvg[0][0:grid_sz_y][0:grid_sz_x]
+
+    if (self.is_groundtruth):
+        mask = (cvg_val > 0)
+    else:
+        mask = (cvg_val >= self.gridbox_cvg_threshold)
+    coord = np.where(mask == 1)
+
+    y = np.asarray(coord[0])
+    x = np.asarray(coord[1])
+
+    mx = x * cell_width
+    my = y * cell_height
+
+    x1 = (np.asarray([net_boxes[0][y[i]][x[i]] for i in xrange(x.size)]) + mx)
+    y1 = (np.asarray([net_boxes[1][y[i]][x[i]] for i in xrange(x.size)]) + my)
+    x2 = (np.asarray([net_boxes[2][y[i]][x[i]] for i in xrange(x.size)]) + mx)
+    y2 = (np.asarray([net_boxes[3][y[i]][x[i]] for i in xrange(x.size)]) + my)
+
+    boxes = np.transpose(np.vstack((x1, y1, x2, y2)))
+    cvgs = np.transpose(np.vstack((x, y, np.asarray(
+        [cvg_val[y[i]][x[i]] for i in xrange(x.size)]))))
+    return boxes, cvgs, mask
+
+
+def vote_boxes(propose_boxes, propose_cvgs, mask, self):
+    """ Vote amongst the boxes using openCV's built-in clustering routine.
+    """
+
+    detections_per_image = []
+    if not propose_boxes.any():
+        return detections_per_image
+
+    ######################################################################
+    # GROUP RECTANGLES Clustering
+    ######################################################################
+    nboxes, weights = cv.groupRectangles(
+        np.array(propose_boxes).tolist(),
+        self.gridbox_rect_thresh,
+        self.gridbox_rect_eps)
+    if len(nboxes):
+        for rect, weight in zip(nboxes, weights):
+            if (rect[3] - rect[1]) >= self.min_height:
+                confidence = math.log(weight[0])
+                detection = [rect[0], rect[1], rect[2], rect[3], confidence]
+                detections_per_image.append(detection)
+
+    return detections_per_image
+
+
+def cluster(self, net_cvg, net_boxes):
+    """
+    Read output of inference and turn into Bounding Boxes
+    """
+    batch_size = net_cvg.shape[0]
+    boxes = np.zeros([batch_size, MAX_BOXES, 5])
+
+    for i in range(batch_size):
+
+        cur_cvg = net_cvg[i]
+        cur_boxes = net_boxes[i]
+
+        if (self.is_groundtruth):
+            # Gather proposals that pass a threshold -
+            propose_boxes, propose_cvgs, mask = gridbox_to_boxes(
+                cur_cvg, cur_boxes, self)
+            # Remove duplicates from ground truth
+            new_array = list({tuple(row) for row in propose_boxes})
+            boxes_cur_image = np.asarray(new_array, dtype=np.float16)
+        else:
+            # Gather proposals that pass a threshold -
+            propose_boxes, propose_cvgs, mask = gridbox_to_boxes(cur_cvg, cur_boxes, self)
+            # Vote across the proposals to get bboxes
+            boxes_cur_image = vote_boxes(propose_boxes, propose_cvgs, mask, self)
+            boxes_cur_image = np.asarray(boxes_cur_image, dtype=np.float16)
+
+        if (boxes_cur_image.shape[0] != 0):
+            [r, c] = boxes_cur_image.shape
+            boxes[i, 0:r, 0:c] = boxes_cur_image
+
+    return boxes

--- a/python/caffe/layers/detectnet/clustering.py
+++ b/python/caffe/layers/detectnet/clustering.py
@@ -12,10 +12,10 @@ class ClusterGroundtruth(caffe.Layer):
     """
     * converts ground truth labels from grid format to list
     * bottom[0] - coverage-label
-        [ batch_size x grid_sz_x x grid_sz_y x 1 ]
+        [ batch_size x num_classes x grid_sz_x x grid_sz_y ]
     * bottom[1] - bbox-label
-        [batch_size x grid_sz_x x grid_sz_y x 4 (xl, yt, xr, yb)]
-    * top [0] - list of groundtruth bbox
+        [batch_size x 4 x grid_sz_x x grid_sz_y (xl, yt, xr, yb)]
+    * top [i] - list of groundtruth bbox for each class
         [ batch_size x max_bbox_per_image x 5 (xl, yt, xr, yb, 0)]
 
     Example prototxt definition:
@@ -24,14 +24,15 @@ class ClusterGroundtruth(caffe.Layer):
         type: 'Python'
         name: 'cluster_gt'
         # gt_bbox_list is a batch_size x MAX_BOXES x 5 blob
-        top: 'gt_bbox_list'
+        top: 'gt_bbox_list-class0'
+        top: 'gt_bbox_list-class1'
         bottom: 'coverage-label'
         bottom: 'bbox-label'
         python_param {
             module: 'caffe.layers.detectnet.clustering'
             layer: 'ClusterGroundtruth'
-            # parameters - img_size_x, img_size_y, stride,
-            param_str : '1248,352,16'
+            # parameters - img_size_x, img_size_y, stride, num_classes
+            param_str : '1248,352,16,2'
         }
         include: { phase: TEST }
     }
@@ -44,17 +45,26 @@ class ClusterGroundtruth(caffe.Layer):
             self.image_size_x = int(plist[0])
             self.image_size_y = int(plist[1])
             self.stride = int(plist[2])
+            self.num_classes = int(plist[3]) if len(plist) > 3 else 1
         except ValueError:
             raise ValueError("Parameter string missing or data type is wrong!")
+        if len(top) != self.num_classes:
+            raise ValueError("Unexpected number of tops: %d != %d" % (len(top), self.num_classes))
 
     def reshape(self, bottom, top):
         n_images = bottom[0].data.shape[0]
-        # Assuming that max booxes per image are MAX_BOXES
-        top[0].reshape(n_images, MAX_BOXES, 5)
+        num_classes = bottom[0].data.shape[1]
+        if num_classes != self.num_classes:
+            raise ValueError("Unexpected number of classes: %d != %d, bottom[0] shape=%s" % (num_classes, self.num_classes, repr(bottom[0].data.shape)))
+        for i in xrange(num_classes):
+            # Assuming that max booxes per image are MAX_BOXES
+            top[i].reshape(n_images, MAX_BOXES, 5)
 
     def forward(self, bottom, top):
-        bbox = cluster(self, bottom[0].data, bottom[1].data)
-        top[0].data[...] = bbox
+        for i in xrange(self.num_classes):
+            data0 = bottom[0].data[:,i:i+1,:,:]
+            bbox = cluster(self, data0, bottom[1].data)
+            top[i].data[...] = bbox
 
     def backward(self, top, propagate_down, bottom):
         pass
@@ -64,10 +74,10 @@ class ClusterDetections(caffe.Layer):
     """
     * convert network output in grid format to list using group rectangles clustering
     * bottom[0] - predicted coverage
-        [ batch_size x grid_sz_x x grid_sz_y x 1 ]
+        [ batch_size x num_classes x grid_sz_x x grid_sz_y ]
     * bottom[1] - predicted bbox
         [batch_size x grid_sz_x x grid_sz_y x 4 (xl, yt, xr, yb)]
-    * top [0] - list of predicted bbox
+    * top [i] - list of predicted bbox for each class
         [ batch_size x max_bbox_per_image x 5 (xl, yt, xr, yb, confidence) ]
 
     Example prototxt definition:
@@ -76,15 +86,16 @@ class ClusterDetections(caffe.Layer):
         type: 'Python'
         name: 'cluster'
         # det_bbox_list is a batch_size x MAX_BOXES x 5 blob
-        top: 'det_bbox_list'
+        top: 'det_bbox_list-class0'
+        top: 'det_bbox_list-class1'
         bottom: 'coverage'
         bottom: 'bbox/regressor'
         python_param {
             module: 'caffe.layers.detectnet.clustering'
             layer: 'ClusterDetections'
             # parameters - img_size_x, img_size_y, stride,
-            # gridbox_cvg_threshold,gridbox_rect_threshold,gridbox_rect_eps,min_height
-            param_str : '1248,352,16,0.05,1,0.025,22'
+            # gridbox_cvg_threshold,gridbox_rect_threshold,gridbox_rect_eps,min_height,num_classes
+            param_str : '1248,352,16,0.05,1,0.025,22,2'
         }
         include: { phase: TEST }
     }
@@ -101,17 +112,26 @@ class ClusterDetections(caffe.Layer):
             self.gridbox_rect_thresh = int(plist[4])
             self.gridbox_rect_eps = float(plist[5])
             self.min_height = int(plist[6])
+            self.num_classes = int(plist[7]) if len(plist) > 7 else 1
         except ValueError:
             raise ValueError("Parameter string missing or data type is wrong!")
+        if len(top) != self.num_classes:
+            raise ValueError("Unexpected number of tops: %d != %d" % (len(top), self.num_classes))
 
     def reshape(self, bottom, top):
         n_images = bottom[0].data.shape[0]
-        # Assuming that max booxes per image are MAX_BOXES
-        top[0].reshape(n_images, MAX_BOXES, 5)
+        num_classes = bottom[0].data.shape[1]
+        if num_classes != self.num_classes:
+            raise ValueError("Unexpected number of classes: %d != %d, bottom[0] shape=%s" % (num_classes, self.num_classes, repr(bottom[0].data.shape)))
+        for i in xrange(num_classes):
+            # Assuming that max booxes per image are MAX_BOXES
+            top[i].reshape(n_images, MAX_BOXES, 5)
 
     def forward(self, bottom, top):
-        bbox = cluster(self, bottom[0].data, bottom[1].data)
-        top[0].data[...] = bbox
+        for i in xrange(self.num_classes):
+            data0 = bottom[0].data[:,i:i+1,:,:]
+            bbox = cluster(self, data0, bottom[1].data)
+            top[i].data[...] = bbox
 
     def backward(self, top, propagate_down, bottom):
         pass

--- a/python/caffe/layers/detectnet/mean_ap.py
+++ b/python/caffe/layers/detectnet/mean_ap.py
@@ -1,0 +1,163 @@
+import numpy as np
+
+import caffe
+
+MAX_BOXES = 50
+
+
+class ScoreDetections(caffe.Layer):
+    """
+    * Marks up bbox predictions as true positive/ false positive and missed gtruth bbox as
+        true negatives
+    * bottom[0] - list of ground truth bbox
+        [batch_size x max_bbox_per_image x 5 (xl, yt, xr, yb, 0) ]
+    * bottom[1] - list of predicted bbox
+        [batch_size x max_bbox_per_image x 5 (xl, yt, xr, yb, confidence) ]
+    * top[0]- Marked up bbox
+        [ batch_size x max_bbox_per_image x 5 (xl, yt, xr, yb, class)]
+        class 1 - true positive, 2 - false positive, 3 - true negative
+
+    Example prototxt definition:
+
+    layer {
+        type: 'Python'
+        name: 'score'
+        top: 'bbox_cl'
+        bottom: 'gt_bbox_list'
+        bottom: 'det_bbox_list'
+        python_param {
+            module: 'caffe.layers.detectnet.mean_ap'
+            layer: 'ScoreDetections'
+        }
+        include: { phase: TEST }
+    }
+    """
+
+    def setup(self, bottom, top):
+        pass
+
+    def reshape(self, bottom, top):
+        n_images = bottom[0].data.shape[0]
+        # Assuming that max booxes per image are MAX_BOXES
+        top[0].reshape(n_images, MAX_BOXES, 5)
+        assert(bottom[0].data.shape[0] == bottom[1].data.shape[0]), "# of images not matching!"
+
+    def forward(self, bottom, top):
+        bbox_list = score_det(bottom[0].data, bottom[1].data)
+        top[0].data[...] = bbox_list
+
+    def backward(self, top, propagate_down, bottom):
+        pass
+
+
+class mAP(caffe.Layer):
+    """
+    * calculates precision, recall, mean average precision from marked up bbox list
+    * bottom[0] - marked up bbox list
+        [ batch_size x max_bbox_per_image x 5(xl, yt, xr, yb, class) ]
+    * top[0] - mAP
+    * top[1] - precision
+    * top[2] - recall
+
+    Example prototxt definition:
+
+    layer {
+        type: 'Python'
+        name: 'mAP'
+        top: 'mAP'
+        top: 'precision'
+        top: 'recall'
+        bottom: 'bbox_cl'
+        python_param {
+            module: 'caffe.layers.detectnet.mean_ap'
+            layer: 'mAP'
+            # parameters - img_size_x, img_size_y, stride
+            param_str : '1248,352,16'
+        }
+        include: { phase: TEST }
+    }
+    """
+
+    def setup(self, bottom, top):
+        pass
+
+    def reshape(self, bottom, top):
+        top[0].reshape(1)
+        top[1].reshape(1)
+        top[2].reshape(1)
+        self.false_positives = 0
+        self.true_positives = 0
+        self.true_negatives = 0
+        self.precision = 0
+        self.recall = 0
+        self.avp = 0
+
+    def forward(self, bottom, top):
+        calcmAP(bottom[0].data, self)
+        top[0].data[...] = self.avp
+        top[1].data[...] = self.precision
+        top[2].data[...] = self.recall
+
+    def backward(self, top, propagate_down, bottom):
+        pass
+
+
+def iou(det, rhs):
+    x_overlap = max(0, min(det[2], rhs[2]) - max(det[0], rhs[0]))
+    y_overlap = max(0, min(det[3], rhs[3]) - max(det[1], rhs[1]))
+    overlap_area = x_overlap * y_overlap
+    if overlap_area == 0:
+        return 0
+    det_area = (det[2]-det[0])*(det[3]-det[1])
+    rhs_area = (rhs[2]-rhs[0])*(rhs[3]-rhs[1])
+    unionarea = det_area + rhs_area - overlap_area
+    return overlap_area/unionarea
+
+
+def divide_zero_is_zero(a, b):
+    return float(a)/float(b) if b != 0 else 0
+
+
+def score_det(gt_bbox_list, det_bbox_list):
+    threshold = 0.7
+    matched_bbox = np.zeros([gt_bbox_list.shape[0], MAX_BOXES, 5])
+
+    for k in range(gt_bbox_list.shape[0]):
+
+        # Remove  zeros from detected bboxes
+        cur_det_bbox = det_bbox_list[k, :, 0:4]
+        cur_det_bbox = np.asarray(filter(lambda a: a.tolist() != [0, 0, 0, 0], cur_det_bbox))
+
+        # Remove  zeros from label bboxes
+        cur_gt_bbox = gt_bbox_list[k, :, 0:4]
+        cur_gt_bbox = np.asarray(filter(lambda a: a.tolist() != [0, 0, 0, 0], cur_gt_bbox))
+
+        gt_matched = np.zeros([cur_gt_bbox.shape[0]])
+        det_matched = np.zeros([cur_det_bbox.shape[0]])
+
+        for i in range(cur_gt_bbox.shape[0]):
+            for j in range(cur_det_bbox.shape[0]):
+                if (iou(cur_det_bbox[j], cur_gt_bbox[i]) >= threshold) and (det_matched[j] == 0):
+                    gt_matched[i] = 1
+                    det_matched[j] = 1
+                    break
+
+        tp = np.asarray([np.append(j, 1) for j in cur_det_bbox[np.where(det_matched == 1)]])
+        fp = np.asarray([np.append(j, 2) for j in cur_det_bbox[np.where(det_matched == 0)]])
+        tn = np.asarray([np.append(j, 3) for j in cur_gt_bbox[np.where(gt_matched == 0)]])
+
+        temp = np.append(tp, fp)
+        temp = np.append(temp, tn)
+        temp = temp.reshape([temp.size/5, 5])
+        matched_bbox[k, 0:temp.shape[0], :] = temp
+
+    return matched_bbox
+
+
+def calcmAP(scored_detections, self):
+    self.true_positives = np.where(scored_detections[:, :, 4] == 1)[0].size
+    self.false_positives = np.where(scored_detections[:, :, 4] == 2)[0].size
+    self.true_negatives = np.where(scored_detections[:, :, 4] == 3)[0].size
+    self.precision = divide_zero_is_zero(self.true_positives, self.true_positives+self.false_positives)*100.00
+    self.recall = divide_zero_is_zero(self.true_positives, self.true_positives+self.true_negatives)*100.00
+    self.avp = self.precision * self.recall / 100.0

--- a/src/caffe/layers/detectnet_transform_layer.cpp
+++ b/src/caffe/layers/detectnet_transform_layer.cpp
@@ -1,0 +1,802 @@
+#ifdef USE_OPENCV
+
+#include "caffe/layers/detectnet_transform_layer.hpp"
+
+#include <opencv2/core/core.hpp>
+#include <opencv2/opencv.hpp>
+
+#include <boost/array.hpp>
+#include <boost/foreach.hpp>
+#include <boost/static_assert.hpp>
+
+#include <algorithm>
+#include <functional>
+#include <string>
+#include <vector>
+
+#include "caffe/util/detectnet_coverage.hpp"
+#include "caffe/util/io.hpp"
+#include "caffe/util/math_functions.hpp"
+#include "caffe/util/rng.hpp"
+
+using namespace cv;  // NOLINT(build/namespaces)
+using boost::array;
+#define foreach_ BOOST_FOREACH
+
+
+namespace caffe {
+
+
+struct AugmentSelection {
+    bool flip;
+    float degree;
+    Point crop;
+    float scale;
+    float hue_rotation;
+    float saturation;
+};
+
+
+template<typename Dtype>
+DetectNetTransformationLayer<Dtype>::DetectNetTransformationLayer(
+    const LayerParameter& param) :
+    Layer<Dtype>(param),
+    a_param_(param.detectnet_augmentation_param()),
+    g_param_(param.detectnet_groundtruth_param()),
+    t_param_(param.transform_param()),
+    coverage_(CoverageGenerator<Dtype>::create(
+        param.detectnet_groundtruth_param())),
+    phase_(param.phase()),
+    rng_(new Caffe::RNG(caffe_rng_rand())) {}
+
+
+template <typename Dtype>
+void DetectNetTransformationLayer<Dtype>::LayerSetUp(
+    const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+  // retrieve mean image or values:
+  if (t_param_.has_mean_file()) {
+    size_t image_x = bottom[0]->width();
+    size_t image_y = bottom[0]->height();
+
+    retrieveMeanImage(Size(image_x, image_y));
+
+  } else if (t_param_.mean_value_size() != 0) {
+    retrieveMeanChannels();
+  }
+}
+
+
+template<typename Dtype>
+void DetectNetTransformationLayer<Dtype>::retrieveMeanImage(Size dimensions) {
+  CHECK(t_param_.has_mean_file());
+
+  const string& mean_file = t_param_.mean_file();
+  BlobProto blob_proto;
+  Blob<Dtype> data_mean;
+
+  ReadProtoFromBinaryFileOrDie(mean_file, &blob_proto);
+  data_mean.FromProto(blob_proto);
+  data_mean_ = blobToMats(data_mean).at(0);
+
+  // resize, if dimensions were defined:
+  if (dimensions.area() > 0) {
+    resize(data_mean_, data_mean_, dimensions, cv::INTER_CUBIC);
+  }
+  // scale from 0..255 to 0..1:
+  data_mean_ /= Dtype(UINT8_MAX);
+}
+
+
+template<typename Dtype>
+void DetectNetTransformationLayer<Dtype>::retrieveMeanChannels() {
+  switch (t_param_.mean_value_size()) {
+    case 1:
+      mean_values_.fill(t_param_.mean_value(0) / Dtype(UINT8_MAX));
+      break;
+    case 3:
+      for (size_t iChannel = 0; iChannel != 3; ++iChannel) {
+        mean_values_[iChannel] =
+            t_param_.mean_value(iChannel) / Dtype(UINT8_MAX);
+      }
+      break;
+    case 0:
+    default:
+      break;
+  }
+}
+
+
+template<typename Dtype>
+void DetectNetTransformationLayer<Dtype>::Reshape(
+    const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top
+) {
+  // accept only three channel images:
+  CHECK_EQ(bottom[0]->channels(), 3);
+  // accept only equal numbers of labels and images:
+  CHECK_EQ(bottom[0]->num(), bottom[1]->num());
+  // resize mean image if it exists:
+  if (t_param_.has_mean_file()) {
+    size_t image_x = bottom[0]->width();
+    size_t image_y = bottom[0]->height();
+    retrieveMeanImage(Size(image_x, image_y));
+  }
+  // resize image output layer: (never changes /wrt input blobs)
+  top[0]->Reshape(
+      bottom[0]->num(),
+      bottom[0]->channels(),
+      g_param_.image_size_y(),
+      g_param_.image_size_x());
+  // resize tensor output layer: (never changes /wrt input blobs)
+  Vec3i tensorDimensions = coverage_->dimensions();
+  top[1]->Reshape(
+      bottom[1]->num(),
+      tensorDimensions(0),
+      tensorDimensions(1),
+      tensorDimensions(2));
+}
+
+
+template<typename Dtype>
+typename DetectNetTransformationLayer<Dtype>::Mat3v
+DetectNetTransformationLayer<Dtype>::dataToMat(
+    const Dtype* _data,
+    Size dimensions
+) const {
+  // NOLINT_NEXT_LINE(whitespace/line_length)
+  // CODE FROM https://github.com/BVLC/caffe/blob/4874c01487/examples/cpp_classification/classification.cpp#L125-137
+  // The format of the mean file is planar 32-bit float BGR or grayscale.
+  vector<Mat> channels; channels.reserve(3);
+
+  Dtype* data = const_cast<Dtype*>(_data);
+  for (size_t iChannel = 0; iChannel != 3; ++iChannel) {
+    // Extract an individual channel. This does not perform a datacopy, so doing
+    //  this in a performance critical location should be fine.
+    Mat channel(dimensions, cv::DataType<Dtype>::type, data);
+    channels.push_back(channel);
+    data += dimensions.area();
+  }
+
+  // Merge the separate channels into a single image.
+  Mat3v result;
+  merge(channels, result);
+
+  return result;
+}
+
+
+template<typename Dtype>
+vector<typename DetectNetTransformationLayer<Dtype>::Mat3v>
+DetectNetTransformationLayer<Dtype>::blobToMats(
+    const Blob<Dtype>& images
+) const {
+  CHECK_EQ(images.channels(), 3);
+  vector<Mat3v> result; result.reserve(images.num());
+
+  for (size_t iImage = 0; iImage != images.num(); ++iImage) {
+    const Dtype* image_data = &images.cpu_data()[
+        images.offset(iImage, 0, 0, 0)];
+
+    result.push_back(dataToMat(
+        image_data,
+        Size(images.width(), images.height())));
+  }
+
+  return result;
+}
+
+
+template<typename Dtype>
+vector<vector<typename DetectNetTransformationLayer<Dtype>::BboxLabel> >
+DetectNetTransformationLayer<Dtype>::blobToLabels(
+    const Blob<Dtype>& labels
+) const {
+  vector<vector<BboxLabel > > result; result.reserve(labels.num());
+
+  for (size_t iLabel = 0; iLabel != labels.num(); ++iLabel) {
+    const Dtype* source = &labels.cpu_data()[
+        labels.offset(iLabel, 0, 0, 0)
+    ];
+
+    size_t numOfBbox = static_cast<size_t>(source[0]);
+    size_t bboxLen = static_cast<size_t>(source[1]);
+    CHECK_EQ(bboxLen, sizeof(BboxLabel) / sizeof(Dtype));
+    CHECK_LE(numOfBbox, labels.height());
+    // exclude header
+    source += bboxLen;
+    // convert label into typed struct:
+    result.push_back(vector<BboxLabel>(
+        reinterpret_cast<const BboxLabel*>(source),
+        reinterpret_cast<const BboxLabel*>(source + bboxLen * numOfBbox)));
+  }
+
+  return result;
+}
+
+
+template<typename Dtype>
+struct toDtype : public std::unary_function<float, Dtype> {
+  Dtype operator() (const Vec<Dtype, 1>& value) { return value(0); }
+};
+template<typename Dtype>
+void DetectNetTransformationLayer<Dtype>::matToBlob(
+    const Mat3v& source,
+    Dtype* destination
+) const {
+  std::vector<Mat1v> channels;
+  split(source, channels);
+
+  size_t offset = 0;
+  for (size_t iChannel = 0; iChannel != channels.size(); ++iChannel) {
+    const Mat1v& channel = channels[iChannel];
+
+    std::transform(
+        channel.begin(),
+        channel.end(),
+        &destination[offset],
+        toDtype<Dtype>());
+
+    offset += channel.total();
+  }
+}
+
+
+template<typename Dtype>
+void DetectNetTransformationLayer<Dtype>::matsToBlob(
+    const vector<Mat3v>& _source,
+    Blob<Dtype>* _dest
+) const {
+  for (size_t iImage = 0; iImage != _source.size(); ++iImage) {
+    Dtype* destination = &_dest->mutable_cpu_data()[
+        _dest->offset(iImage, 0, 0, 0)
+    ];
+    const Mat3v& source = _source[iImage];
+    matToBlob(source, destination);
+  }
+}
+
+
+template<typename Dtype>
+void DetectNetTransformationLayer<Dtype>::pixelMeanSubtraction(
+    Mat3v* source
+) const {
+  *source -= data_mean_;
+}
+
+
+template<typename Dtype>
+void DetectNetTransformationLayer<Dtype>::channelMeanSubtraction(
+    Mat3v* source
+) const {
+  vector<Mat1f> channels;
+  split(*source, channels);
+  for (size_t iChannel = 0; iChannel != channels.size(); ++iChannel) {
+    channels[iChannel] -= mean_values_[iChannel];
+  }
+  merge(channels, *source);
+}
+
+
+template<typename Dtype>
+void DetectNetTransformationLayer<Dtype>::meanSubtract(Mat3v* source) const {
+  if (t_param_.has_mean_file()) {
+    pixelMeanSubtraction(source);
+  } else if (t_param_.mean_value_size() != 0) {
+    channelMeanSubtraction(source);
+  }
+}
+
+
+template<typename Dtype>
+Dtype DetectNetTransformationLayer<Dtype>::randDouble() {
+  rng_t* rng =
+      static_cast<rng_t*>(rng_->generator());
+  uint64_t randval = (*rng)();
+
+  return (Dtype(randval) / Dtype(rng_t::max()));
+}
+
+
+template<typename Dtype>
+void DetectNetTransformationLayer<Dtype>::Forward_cpu(
+    const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top
+) {
+  // verify image parameters:
+  const int image_count = bottom[0]->num();
+  // verify label parameters:
+  const int label_count = bottom[1]->num();
+  CHECK_EQ(image_count, label_count);
+
+  const vector<Mat3v> inputImages = blobToMats(*bottom[0]);
+  const vector<vector<BboxLabel > > labels = blobToLabels(*bottom[1]);
+
+  vector<Mat3v> outputImages(inputImages.size());
+  Blob<Dtype>& outputLabels = *top[1];
+
+  for (size_t iImage = 0; iImage != inputImages.size(); ++iImage) {
+    const Mat3v& inputImage = inputImages[iImage];
+    const vector<BboxLabel >& inputLabel = labels[iImage];
+
+    Mat3v& outputImage = outputImages[iImage];
+    Dtype* outputLabel = &outputLabels.mutable_cpu_data()[
+        outputLabels.offset(iImage, 0, 0, 0)
+    ];
+
+    transform(inputImage, inputLabel, &outputImage, outputLabel);
+  }
+  // emplace images in output image blob:
+  matsToBlob(outputImages, top[0]);
+}
+
+template<typename Dtype>
+void DetectNetTransformationLayer<Dtype>::transform(
+    const Mat3v& img,
+    const vector<BboxLabel >& bboxlist,
+    Mat3v* img_aug,
+    Dtype* transformed_label
+) {
+  uint32_t image_x = g_param_.image_size_x();
+  uint32_t image_y = g_param_.image_size_y();
+
+  // Perform mean subtraction on un-augmented image:
+  Mat3v img_temp = img.clone();  // size determined by scale
+  // incoming float images have values from 0..255, but OpenCV expects these
+  //  values to be from 0..1:
+  img_temp /= Dtype(UINT8_MAX);
+  *img_aug = Mat::zeros(image_y, image_x, img.type());
+  vector<BboxLabel > bboxlist_aug;
+  AugmentSelection as;
+  // We only do random transform as augmentation when training.
+  if (this->phase_ == TRAIN) {
+    // TODO: combine hueRotation and desaturation if performance is a concern,
+    //  as we must redundantly convert to and from HSV colorspace for each
+    //  operation
+    as.hue_rotation = augmentation_hueRotation(img_temp, &img_temp);
+    as.saturation = augmentation_desaturation(img_temp, &img_temp);
+    // mean subtraction must occur after color augmentations as colorshift
+    //  outside of 0..1 invalidates scale
+    meanSubtract(&img_temp);
+    // images now bounded from -0.5...0.5
+    as.scale = augmentation_scale(img_temp, img_aug, bboxlist, &bboxlist_aug);
+    as.degree =
+        augmentation_rotate(*img_aug, &img_temp, bboxlist_aug, &bboxlist_aug);
+    as.flip = augmentation_flip(img_temp, img_aug, bboxlist_aug, &bboxlist_aug);
+    as.crop = augmentation_crop(
+        *img_aug,
+        &img_temp,
+        bboxlist_aug,
+        &bboxlist_aug);
+    *img_aug = img_temp;
+  } else {
+    // perform mean subtraction:
+    meanSubtract(&img_temp);
+
+    // deterministically scale the image and ground-truth, if requested:
+    transform_scale(
+        img_temp,
+        img_aug,
+        bboxlist,
+        &bboxlist_aug,
+        Size(image_x, image_y));
+  }
+
+  CHECK_EQ(img_aug->cols, image_x);
+  CHECK_EQ(img_aug->rows, image_y);
+
+  // generate transformed_label based on bboxlist_aug
+  coverage_->generate(transformed_label, bboxlist_aug);
+
+  // networks expect floats bounded from -255..255, so rescale to this range:
+  *img_aug *= Dtype(UINT8_MAX);
+}
+
+
+template<typename Dtype>
+float DetectNetTransformationLayer<Dtype>::augmentation_scale(
+    const Mat3v& img_src,
+    Mat3v* img_dst,
+    const vector<BboxLabel >& bboxList,
+    vector<BboxLabel >* bboxList_aug
+) {
+  bool doScale = randDouble() <= a_param_.scale_prob();
+  // linear shear into [scale_min, scale_max]
+  float scale =
+      a_param_.scale_min() +
+      (a_param_.scale_max() - a_param_.scale_min()) *
+      randDouble();
+
+  if (doScale) {
+    // scale uniformly across both axes by some random value:
+    Size scaleSize(round(img_src.cols * scale), round(img_src.rows * scale));
+    transform_scale(
+        img_src,
+        img_dst,
+        bboxList,
+        bboxList_aug,
+        scaleSize);
+  } else {
+    *img_dst = img_src.clone();
+    *bboxList_aug = bboxList;
+    scale = 1;
+  }
+
+  return scale;
+}
+
+
+template<typename Dtype>
+void DetectNetTransformationLayer<Dtype>::transform_scale(
+    const Mat3v& img,
+    Mat3v* img_temp,
+    const vector<BboxLabel >& bboxList,
+    vector<BboxLabel >* _bboxList_aug,
+    const Size& size
+) {
+  // perform scaling if desired size and image size are non-equal:
+  if (size.height != img.rows || size.width != img.cols) {
+    Dtype scale_x = (Dtype)size.width / img.cols;
+    Dtype scale_y = (Dtype)size.height / img.rows;
+
+    resize(img, *img_temp, size, cv::INTER_CUBIC);
+
+    vector<BboxLabel > bboxList_aug;
+    foreach_(BboxLabel label, bboxList) {  // for every bbox:
+      // resize by scale
+      label.bbox = Rectv(
+          label.bbox.x * scale_x,
+          label.bbox.y * scale_y,
+          label.bbox.width * scale_x,
+          label.bbox.height * scale_y);
+      bboxList_aug.push_back(label);
+    }
+
+    _bboxList_aug->swap(bboxList_aug);
+
+  } else {
+    *img_temp = img.clone();
+    *_bboxList_aug = bboxList;
+  }
+}
+
+
+template<typename Dtype>
+Point DetectNetTransformationLayer<Dtype>::augmentation_crop(
+    const Mat3v& img_src,
+    Mat3v* img_dst,
+    const vector<BboxLabel >& bboxList,
+    vector<BboxLabel >* bboxList_aug
+) {
+  bool doCrop = randDouble() <= a_param_.crop_prob();
+  Size2i crop(g_param_.image_size_x(), g_param_.image_size_y());
+  Size2i shift(a_param_.shift_x(), a_param_.shift_y());
+  Size2i imgSize(img_src.cols, img_src.rows);
+  Point2i offset, inner, outer;
+  if (doCrop) {
+    // perform a random crop, bounded by the difference between the network's
+    //  input and the size of the incoming image. Add a user-defined shift to
+    //  the max range of the crop offset.
+    offset = Point2i(
+        round(randDouble() * (imgSize.width  - crop.width  + shift.width)),
+        round(randDouble() * (imgSize.height - crop.height + shift.height)));
+    offset -= Point2i(shift.width / 2, shift.height / 2);
+  } else {
+    // perform a deterministic crop, placing the image in the middle of the
+    //  network's input region:
+    offset = Point2i(
+        (imgSize.width  - crop.width) / 2,
+        (imgSize.height - crop.height) / 2);
+  }
+  inner = Point2i(std::max(0,  1 * offset.x), std::max(0,  1 * offset.y));
+  outer = Point2i(std::max(0, -1 * offset.x), std::max(0, -1 * offset.y));
+
+  // crop / grow to size:
+  transform_crop(
+      img_src,
+      img_dst,
+      bboxList,
+      bboxList_aug,
+      Rect(inner, crop),
+      crop,
+      outer);
+  return offset;
+}
+
+
+template<typename Dtype>
+void DetectNetTransformationLayer<Dtype>::transform_crop(
+    const Mat3v& img_src,
+    Mat3v* img_dst,
+    const vector<BboxLabel>& bboxlist,
+    vector<BboxLabel>* _bboxlist_aug,
+    Rect inner,
+    Size2i dst_size,
+    Point2i outer
+) const {
+  // ensure src_rect fits within img_src:
+  Rect src_rect = inner & Rect(Point(0, 0), Size2i(img_src.cols, img_src.rows));
+  // dst_rect has a size the same as src_rect:
+  Rect dst_rect(outer, src_rect.size());
+  // ensure dst_rect fits within img_dst:
+  dst_rect &= Rect(Point(0, 0), dst_size);
+  // assert src_rect and dst_rect have the same size:
+  src_rect = Rect(src_rect.tl(), dst_rect.size());
+  // Fail with an Opencv exception if any of these are negative
+
+  // no operation is needed in the case of zero transformations:
+  if (src_rect == dst_rect
+    && src_rect.tl() == Point2i(0, 0)
+    && src_rect.size() == dst_size
+    && dst_size == Size2i(img_src.cols, img_src.rows)) {
+    // no crop is needed:
+    *img_dst = img_src.clone();
+    *_bboxlist_aug = bboxlist;
+  } else {
+    // construct a destination matrix:
+    *img_dst = Mat3v(dst_size);
+    // and fill with black:
+    img_dst->setTo(Scalar(-0.5, -0.5, -0.5));
+
+    // define destinationROI inside of destination mat:
+    Mat3v destinationROI = (*img_dst)(dst_rect);
+    // sourceROI inside of source mat:
+    Mat3v sourceROI = img_src(src_rect);
+    // copy sourceROI into destinationROI:
+    sourceROI.copyTo(destinationROI);
+
+    // translate all bounding boxes by the new offset, -inner + outer:
+    Point2v bboxOffset = dst_rect.tl() - src_rect.tl();
+    vector<BboxLabel> bboxlist_aug;
+    foreach_(const BboxLabel& label, bboxlist) {  // for every bbox
+      BboxLabel cropped = label;
+      // shift topLeft by offset
+      cropped.bbox += bboxOffset;
+
+      // Add to list of bboxes.
+      bboxlist_aug.push_back(cropped);
+    }
+    _bboxlist_aug->swap(bboxlist_aug);
+  }
+}
+
+
+template<typename Dtype>
+bool DetectNetTransformationLayer<Dtype>::augmentation_flip(
+    const Mat3v& img_src,
+    Mat3v* img_aug,
+    const vector<BboxLabel >& bboxlist,
+    vector<BboxLabel >* _bboxlist_aug) {
+  bool doflip = randDouble() <= a_param_.flip_prob();
+  if (doflip) {
+    flip(img_src, *img_aug, 1);
+    float w = img_src.cols;
+
+    vector <BboxLabel > bboxlist_aug;
+    foreach_(BboxLabel label, bboxlist) {  // for every bbox
+      // flip X across the width of the image:
+      label.bbox.x = w - label.bbox.x - 1.0f - label.bbox.width;
+      // Y, width, height stay the same
+
+      bboxlist_aug.push_back(label);
+    }
+    _bboxlist_aug->swap(bboxlist_aug);
+  } else {
+    *img_aug = img_src.clone();
+    *_bboxlist_aug = bboxlist;
+  }
+  return doflip;
+}
+
+
+template<typename Dtype>
+typename DetectNetTransformationLayer<Dtype>::Mat1v
+DetectNetTransformationLayer<Dtype>::getTransformationMatrix(
+    Rect region,
+    Dtype rotation
+) const {
+  Size2v size(region.width, region.height);
+  Point2v center = size * (Dtype)0.5;
+  array<Point2f, 4> srcTri, dstTri;
+
+  // Define a rotated rectangle for our initial position, retrieving points
+  //  for each of our 4 corners:
+  RotatedRect initialRect(center, size, 0.0);
+  initialRect.points(srcTri.c_array());
+  // Another rotated rectangle for our eventual position.
+  RotatedRect rotatedRect(center, size, rotation);
+  // retrieve boundingRect, whose top-left will be below zero:
+  Rectv boundingRect = rotatedRect.boundingRect();
+  // push all points up by the the topleft boundingRect's delta from
+  //  the origin:
+  rotatedRect = RotatedRect(center - boundingRect.tl(), size, rotation);
+  // retrieve points for each of the rotated rectangle's 4 corners:
+  rotatedRect.points(dstTri.c_array());
+
+  // compute the affine transformation of this operation:
+  Mat1v result(2, 3);
+  result = getAffineTransform(srcTri.c_array(), dstTri.c_array());
+  // return the transformation matrix
+  return result;
+}
+
+
+template<typename Dtype>
+Rect DetectNetTransformationLayer<Dtype>::getBoundingRect(
+    Rect region,
+    Dtype rotation
+) const {
+  Size2v size(region.width, region.height);
+  Point2v center = size * (Dtype)0.5;
+
+  return RotatedRect(center, size, rotation).boundingRect();
+}
+
+
+template<typename Dtype>
+float DetectNetTransformationLayer<Dtype>::augmentation_rotate(
+    const Mat3v& img_src,
+    Mat3v* img_aug,
+    const vector<BboxLabel >& bboxList,
+    vector<BboxLabel >* _bboxlist_aug) {
+  bool doRotate = randDouble() <= a_param_.rotation_prob();
+  float degree = (randDouble() - 0.5) * 2 * a_param_.max_rotate_degree();
+
+  if (doRotate && std::abs(degree) > FLT_EPSILON) {
+    Rect roi(0, 0, img_src.cols, img_src.rows);
+    // determine new bounding rect:
+    Size2i boundingSize = getBoundingRect(roi, degree).size();
+    // determine rotation matrix:
+    Mat1v transformationMatrix = getTransformationMatrix(roi, degree);
+
+    // construct a destination matrix large enough to contain the rotated image:
+    *img_aug = Mat3v(boundingSize);
+    // and fill with black:
+    img_aug->setTo(Scalar(-0.5, -0.5, -0.5));
+    // warp old image into new buffer, maintaining the background:
+    warpAffine(
+        img_src,
+        *img_aug,
+        transformationMatrix,
+        boundingSize,
+        INTER_LINEAR,
+        BORDER_TRANSPARENT);
+
+    vector<BboxLabel > bboxlist_aug;
+    foreach_(BboxLabel label, bboxList) {  // for each bbox:
+      Mat1v center(3, 1);
+      // center of bbox as midpoint between topLeft and bottomRight:
+      Point2v center_point = (label.bbox.tl() + label.bbox.br()) * 0.5;
+      center.template at<Dtype>(0, 0) = center_point.x;
+      center.template at<Dtype>(1, 0) = center_point.y;
+      center.template at<Dtype>(2, 0) = 1.0;
+
+      // rotate around the origin:
+      Mat1v new_center(3, 1);
+      new_center = transformationMatrix * center;
+
+      // rotated bbox with topleft as midpoint - size/2 and prior size
+      Point2v new_center_point(
+          new_center.template at<Dtype>(0, 0),
+          new_center.template at<Dtype>(1, 0));
+      Rectv rotated(
+          new_center_point - (label.bbox.br() - center_point),
+          label.bbox.size());
+      label.bbox = rotated;
+
+      // Add to list of bboxes. Note that it's possible for the bounding box
+      // to be out of the display area at this point
+      bboxlist_aug.push_back(label);
+    }
+    _bboxlist_aug->swap(bboxlist_aug);
+  } else {
+    *img_aug = img_src.clone();
+    *_bboxlist_aug = bboxList;
+    degree = 0.0f;
+  }
+
+  return degree;
+}
+
+
+template<typename Dtype>
+float DetectNetTransformationLayer<Dtype>::augmentation_hueRotation(
+    const Mat3v& img,
+    Mat3v* result) {
+  bool doHueRotate = randDouble() <= a_param_.hue_rotation_prob();
+  // rotate hue by this amount in degrees
+  float rotation =
+      (randDouble()                       // range: 0..1
+      * (2.0 * a_param_.hue_rotation()))  // range: 0..2*rot
+      - a_param_.hue_rotation();          // range: -rot..rot
+  // clamp to -180d..180d
+  rotation = std::max(std::min(rotation, 180.0f), -180.0f);
+
+  // if we're actually rotating:
+  if (doHueRotate && std::abs(rotation) > FLT_EPSILON) {
+    // convert to HSV colorspace
+    cvtColor(img, *result, COLOR_BGR2HSV);
+
+    // retrieve the hue channel:
+    static const array<int, 2> from_mix = {{0, 0}};
+    Mat1v hueChannel(result->rows, result->cols);
+    mixChannels(
+        result, 1,
+        &hueChannel, 1,
+        from_mix.data(), from_mix.size()/2);
+
+    // shift the hue's value by some amount:
+    hueChannel += rotation;
+
+    // place hue-rotated channel back in result matrix:
+    // NOLINT_NEXT_LINE(whitespace/comma)
+    static const array<int, 6> to_mix = {{3,0, 1,1, 2,2}};
+    const array<Mat, 2> to_channels = {{*result, hueChannel}};
+    mixChannels(
+        to_channels.data(), 2,
+        result, 1,
+        to_mix.data(), to_mix.size()/2);
+
+    // back to BGR colorspace
+    cvtColor(*result, *result, COLOR_HSV2BGR);
+  } else {
+    *result = img;
+    rotation = 0.0f;
+  }
+
+  return rotation;
+}
+
+
+template<typename Dtype>
+float DetectNetTransformationLayer<Dtype>::augmentation_desaturation(
+    const Mat3v& img,
+    Mat3v* result) {
+  bool doDesaturate = randDouble() <= a_param_.desaturation_prob();
+  // scale saturation by this amount:
+  float saturation =
+      1.0                           // inverse
+    - randDouble()                  // range: 0..1
+    * a_param_.desaturation_max();  // range: 0..max
+
+  // if our random value is large enough to produce noticeable desaturation:
+  if (doDesaturate && (saturation < 1.0 - 1.0/UINT8_MAX)) {
+    // convert to HSV colorspace
+    cvtColor(img, *result, COLOR_BGR2HSV);
+
+    // retrieve the saturation channel:
+    static const array<int, 2> from_mix = {{1, 0}};
+    Mat1v saturationChannel(result->rows, result->cols);
+    mixChannels(
+        result, 1,
+        &saturationChannel, 1,
+        from_mix.data(), from_mix.size()/2);
+    // de-saturate the channel by an amount:
+    saturationChannel *= saturation;
+
+    // place de-saturated channel back in result matrix:
+    // NOLINT_NEXT_LINE(whitespace/comma)
+    static const array<int, 6> to_mix = {{0,0, 3,1, 2,2}};
+    const array<Mat, 2> to_channels = {{*result, saturationChannel}};
+    mixChannels(
+        to_channels.data(), 2,
+        result, 1,
+        to_mix.data(), to_mix.size()/2);
+
+    // convert back to BGR colorspace:
+    cvtColor(*result, *result, COLOR_HSV2BGR);
+  } else {
+    *result = img;
+    saturation = 1.0;
+  }
+
+  return saturation;
+}
+
+
+INSTANTIATE_CLASS(DetectNetTransformationLayer);
+REGISTER_LAYER_CLASS(DetectNetTransformation);
+
+}  // namespace caffe
+
+#endif  // USE_OPENCV

--- a/src/caffe/layers/detectnet_transform_layer.cpp
+++ b/src/caffe/layers/detectnet_transform_layer.cpp
@@ -81,7 +81,7 @@ void DetectNetTransformationLayer<Dtype>::retrieveMeanImage(Size dimensions) {
 
   // resize, if dimensions were defined:
   if (dimensions.area() > 0) {
-    resize(data_mean_, data_mean_, dimensions, cv::INTER_CUBIC);
+    cv::resize(data_mean_, data_mean_, dimensions, 0, 0, cv::INTER_CUBIC);
   }
   // scale from 0..255 to 0..1:
   data_mean_ /= Dtype(UINT8_MAX);
@@ -358,7 +358,7 @@ void DetectNetTransformationLayer<Dtype>::transform(
     // mean subtraction must occur after color augmentations as colorshift
     //  outside of 0..1 invalidates scale
     meanSubtract(&img_temp);
-    // images now bounded from -0.5...0.5
+    // images now bounded from [-1,1] (range is dependent on mean subtraction)
     as.scale = augmentation_scale(img_temp, img_aug, bboxlist, &bboxlist_aug);
     as.degree =
         augmentation_rotate(*img_aug, &img_temp, bboxlist_aug, &bboxlist_aug);
@@ -438,9 +438,7 @@ void DetectNetTransformationLayer<Dtype>::transform_scale(
   if (size.height != img.rows || size.width != img.cols) {
     Dtype scale_x = (Dtype)size.width / img.cols;
     Dtype scale_y = (Dtype)size.height / img.rows;
-
-    resize(img, *img_temp, size, cv::INTER_CUBIC);
-
+    cv::resize(img, *img_temp, size, 0, 0, cv::INTER_CUBIC);
     vector<BboxLabel > bboxList_aug;
     foreach_(BboxLabel label, bboxList) {  // for every bbox:
       // resize by scale
@@ -536,7 +534,7 @@ void DetectNetTransformationLayer<Dtype>::transform_crop(
     // construct a destination matrix:
     *img_dst = Mat3v(dst_size);
     // and fill with black:
-    img_dst->setTo(Scalar(-0.5, -0.5, -0.5));
+    img_dst->setTo(Scalar(0, 0, 0));
 
     // define destinationROI inside of destination mat:
     Mat3v destinationROI = (*img_dst)(dst_rect);
@@ -652,7 +650,7 @@ float DetectNetTransformationLayer<Dtype>::augmentation_rotate(
     // construct a destination matrix large enough to contain the rotated image:
     *img_aug = Mat3v(boundingSize);
     // and fill with black:
-    img_aug->setTo(Scalar(-0.5, -0.5, -0.5));
+    img_aug->setTo(Scalar(0, 0, 0));
     // warp old image into new buffer, maintaining the background:
     warpAffine(
         img_src,

--- a/src/caffe/layers/detectnet_transform_layer.cu
+++ b/src/caffe/layers/detectnet_transform_layer.cu
@@ -1,3 +1,5 @@
+#ifdef USE_OPENCV
+
 #include <math.h>
 #include <math_constants.h>
 #include <opencv2/core/core.hpp>
@@ -430,3 +432,5 @@ INSTANTIATE_LAYER_GPU_FUNCS(DetectNetTransformationLayer);
 
 
 }  // namespace caffe
+
+#endif

--- a/src/caffe/layers/detectnet_transform_layer.cu
+++ b/src/caffe/layers/detectnet_transform_layer.cu
@@ -1,0 +1,432 @@
+#include <math.h>
+#include <math_constants.h>
+#include <opencv2/core/core.hpp>
+
+#include <vector>
+
+#include "caffe/layers/detectnet_transform_layer.hpp"
+#include "caffe/util/detectnet_coverage.hpp"
+#include "caffe/util/gpu_memory.hpp"
+#include "caffe/util/math_functions.hpp"
+
+namespace caffe {
+
+// Calculate the location in the image from the loop index
+__device__ void get_pixel_indices(const int loop_index,
+    const uint4 shape, int* x, int* y, int* n
+) {
+  int idx = loop_index;
+  *n = idx / (shape.y * shape.x);
+  idx -= *n * shape.y * shape.x;
+  *y = idx / shape.x;
+  idx -= *y * shape.x;
+  *x = idx;
+}
+
+// https://www.cs.rit.edu/~ncs/color/t_convert.html
+template <typename Dtype>
+__device__ void convert_rgb_to_hsv(
+    Dtype r, Dtype g, Dtype b,
+    Dtype* h, Dtype* s, Dtype* v
+) {
+  Dtype min_v = min(min(r, g), b);
+  Dtype max_v = max(max(r, g), b);  // NOLINT(build/include_what_you_use)
+  Dtype delta = max_v - min_v;
+
+  if (max_v == 0 || delta == 0) {
+    *h = 0;
+    *s = 0;
+    *v = max_v;
+    return;
+  }
+
+  if (r == max_v) {
+    *h = (g - b) / delta;
+  } else if (g == max_v) {
+    *h = 2 + (b - r) / delta;
+  } else {
+    *h = 4 + (r - g) / delta;
+  }
+
+  *h *= 60;
+  if (h < 0) {
+    *h += 360;
+  }
+  *s = delta / max_v;
+  *v = max_v;
+}
+
+
+// https://www.cs.rit.edu/~ncs/color/t_convert.html
+template <typename Dtype>
+__device__ void convert_hsv_to_rgb(
+    Dtype h, Dtype s, Dtype v,
+    Dtype* r, Dtype* g, Dtype* b
+) {
+  int i;
+  Dtype f, p, q, t;
+
+  if (s == 0) {
+    *r = v;
+    *g = v;
+    *b = v;
+    return;
+  }
+
+  h /= 60;  // sector 0 to 5
+  i = floor(h);
+  f = h - i;  // factorial part of h
+  p = v * (1 - s);
+  q = v * (1 - s * f);
+  t = v * (1 - s * (1 - f));
+
+  switch (i) {
+    case 0:
+      *r = v;
+      *g = t;
+      *b = p;
+      break;
+    case 1:
+      *r = q;
+      *g = v;
+      *b = p;
+      break;
+    case 2:
+      *r = p;
+      *g = v;
+      *b = t;
+      break;
+    case 3:
+      *r = p;
+      *g = q;
+      *b = v;
+      break;
+    case 4:
+      *r = t;
+      *g = p;
+      *b = v;
+      break;
+    default:  // case 5:
+      *r = v;
+      *g = p;
+      *b = q;
+      break;
+  }
+}
+
+
+template <typename Dtype>
+__global__ void color_transformations(
+    const Dtype* src_data, Dtype* dst_data,
+    const uint4 shape, const AugmentSelection* aug_data
+) {
+  CUDA_KERNEL_LOOP(loop_index, shape.x * shape.y * shape.w) {
+    int x, y, n;
+    get_pixel_indices(loop_index, shape, &x, &y, &n);
+
+    // check what needs doing
+    const AugmentSelection& as = aug_data[n];
+    const bool doHueRotation = (abs(as.hue_rotation) > FLT_EPSILON);
+    const bool doDesaturation = (as.saturation < (1.0 - 1.0/UINT8_MAX));
+
+    // N*cs*hs*ws + H*ws + W
+    int index = n * shape.z * shape.y * shape.x + y * shape.x + x;
+    // hs*ws
+    const int channel_stride = shape.y * shape.x;
+
+    // read
+    Dtype r = src_data[index + 0 * channel_stride];
+    Dtype g = src_data[index + 1 * channel_stride];
+    Dtype b = src_data[index + 2 * channel_stride];
+
+    if (doHueRotation || doDesaturation) {
+      // transform
+      Dtype h, s, v;
+      convert_rgb_to_hsv(r, g, b, &h, &s, &v);
+      if (doHueRotation) {
+        h -= aug_data[n].hue_rotation;
+      }
+      if (doDesaturation) {
+        s *= aug_data[n].saturation;
+      }
+      convert_hsv_to_rgb(h, s, v, &r, &g, &b);
+    }
+
+    // write
+    dst_data[index + 0 * channel_stride] = r;
+    dst_data[index + 1 * channel_stride] = g;
+    dst_data[index + 2 * channel_stride] = b;
+  }
+}
+
+
+// Mean is WxHxC
+// For each pixel in the current image, subtract the corresponding pixel
+// from the mean image
+template <typename Dtype>
+__global__ void pixel_mean_subtraction(
+    Dtype* data, const Dtype* mean_data, const uint4 shape
+) {
+  CUDA_KERNEL_LOOP(loop_index, shape.x * shape.y * shape.w) {
+    int x, y, n;
+    get_pixel_indices(loop_index, shape, &x, &y, &n);
+
+    for (int c = 0; c < shape.z; c++) {
+      // N*cs*hs*ws + C*hs*ws + H*ws + W
+      const int data_idx = (n * shape.z * shape.y * shape.x) +
+        (c * shape.y * shape.x) + (y * shape.x) + x;
+      // C*hs*ws + H*ws + W
+      const int mean_idx = (c * shape.y * shape.x) + (y * shape.x) + x;
+      data[data_idx] -= mean_data[mean_idx];
+    }
+  }
+}
+
+
+// Mean is 1x1xC
+// For each pixel in the current image, subtract the mean pixel
+template <typename Dtype>
+__global__ void channel_mean_subtraction(
+    Dtype* data, const uint4 shape,
+    const Dtype mean_value1, const Dtype mean_value2, const Dtype mean_value3
+) {
+  CUDA_KERNEL_LOOP(loop_index, shape.x * shape.y * shape.w) {
+    int x, y, n;
+    get_pixel_indices(loop_index, shape, &x, &y, &n);
+
+    // N*cs*hs*ws + C*hs*ws + H*ws + W
+    const int data_idx = (n * shape.z * shape.y * shape.x) +(y * shape.x) + x;
+    // hs*ws
+    const int channel_stride = shape.y * shape.x;
+
+    data[data_idx + 0 * channel_stride] -= mean_value1;
+    data[data_idx + 1 * channel_stride] -= mean_value2;
+    data[data_idx + 2 * channel_stride] -= mean_value3;
+  }
+}
+
+
+template <typename Dtype>
+__device__ void rotate_point(
+    const Dtype ax, const Dtype ay,  // original point
+    const Dtype cx, const Dtype cy,  // center point
+    float angle,
+    Dtype* bx, Dtype* by  // destination point
+) {
+  const Dtype s = sin(angle);
+  const Dtype c = cos(angle);
+
+  // translate to origin
+  const Dtype tx = ax - cx;
+  const Dtype ty = ay - cy;
+
+  *bx = (tx * c) - (ty * s) + cx;
+  *by = (tx * s) + (ty * c) + cy;
+}
+
+
+template <typename Dtype>
+__device__ Dtype get_value(
+    const Dtype* data, const uint4& shape,
+    const unsigned int n, const unsigned int c,
+    int y, int x
+) {
+  // Replicate border for 1 pixel
+  if (x == -1) x = 0;
+  if (x == shape.x) x = shape.x - 1;
+  if (y == -1) y = 0;
+  if (y == shape.y) y = shape.y - 1;
+
+  if (x >= 0 && x < shape.x && y >= 0 && y < shape.y) {
+    // N*cs*hs*ws + C*hs*ws + H*ws + W
+    return data[(n * shape.z * shape.y * shape.x) +
+      (c * shape.y * shape.x) + (y * shape.x) + x];
+  } else {
+    return 0;
+  }
+}
+
+
+template <typename Dtype>
+__device__ Dtype cubic_interpolation(const Dtype& d,
+    const Dtype& v1, const Dtype& v2, const Dtype& v3, const Dtype& v4
+) {
+  // d is [0,1], marking the distance from v2 towards v3
+  return v2 + d * (
+      -2.0 * v1 - 3.0 * v2 + 6.0 * v3 - 1.0 * v4 + d * (
+       3.0 * v1 - 6.0 * v2 + 3.0 * v3 + 0.0 * v4 + d * (
+      -1.0 * v1 + 3.0 * v2 - 3.0 * v3 + 1.0 * v4))) / 6.0;
+}
+
+
+// Interpolate in 1D space
+template <typename Dtype>
+__device__ Dtype interpolate_x(
+    const Dtype* data, const uint4& shape,
+    const unsigned int n, const unsigned int c,
+    const int y, const Dtype x
+) {
+  Dtype dx = x - floor(x);
+  return cubic_interpolation(dx,
+      get_value(data, shape, n, c, y, floor(x) - 1),
+      get_value(data, shape, n, c, y, floor(x)),
+      get_value(data, shape, n, c, y, ceil(x)),
+      get_value(data, shape, n, c, y, ceil(x) + 1));
+}
+
+
+// Interpolate in 2D space
+template <typename Dtype>
+__device__ Dtype interpolate_xy(
+    const Dtype* data, const uint4& shape,
+    const unsigned int n, const unsigned int c,
+    const Dtype y, const Dtype x
+) {
+  Dtype dy = y - floor(y);
+  return cubic_interpolation(dy,
+      interpolate_x(data, shape, n, c, floor(y) - 1, x),
+      interpolate_x(data, shape, n, c, floor(y), x),
+      interpolate_x(data, shape, n, c, ceil(y), x),
+      interpolate_x(data, shape, n, c, ceil(y) + 1, x));
+}
+
+
+template <typename Dtype>
+__global__ void spatial_transformations(
+    const Dtype* src_data, const uint4 src_shape,
+    const AugmentSelection* aug_data,
+    Dtype* dst_data, const uint4 dst_shape
+) {
+  CUDA_KERNEL_LOOP(loop_index, dst_shape.x * dst_shape.y * dst_shape.w) {
+    int dst_x, dst_y, n;
+    get_pixel_indices(loop_index, dst_shape, &dst_x, &dst_y, &n);
+    const AugmentSelection& as = aug_data[n];
+
+    // calculate src pixel indices for this thread
+    Dtype x = dst_x;
+    Dtype y = dst_y;
+    // crop
+    x += as.crop_offset.x;
+    y += as.crop_offset.y;
+    // rotate
+    if (abs(as.rotation) > FLT_EPSILON) {
+      const Dtype w_before = as.scale.width - 1;
+      const Dtype h_before = as.scale.height - 1;
+      const float angle = as.rotation * CUDART_PI_F / 180.0f;
+      const Dtype w_after = abs(w_before * cos(angle)) +
+        abs(h_before * sin(angle));
+      const Dtype h_after = abs(w_before * sin(angle)) +
+        abs(h_before * cos(angle));
+      rotate_point(x, y, w_after / 2.0f, h_after / 2.0f,
+          -angle, &x, &y);
+      x -= (w_after - w_before) / 2.0f;
+      y -= (h_after - h_before) / 2.0f;
+    }
+    // scale
+    if (src_shape.x != as.scale.width) {
+      x *= Dtype(src_shape.x - 1) / (as.scale.width - 1);
+    }
+    if (src_shape.y != as.scale.height) {
+      y *= Dtype(src_shape.y - 1) / (as.scale.height - 1);
+    }
+    // flip
+    if (as.flip) {
+      x = (src_shape.x - x - 1.0);
+    }
+
+    for (int c = 0; c < dst_shape.z; c++) {
+      // N*cs*hs*ws + C*hs*ws + H*ws + W
+      const int dst_idx = (n * dst_shape.z * dst_shape.y * dst_shape.x) +
+        (c * dst_shape.y * dst_shape.x) + (dst_y * dst_shape.x) + dst_x;
+      dst_data[dst_idx] = interpolate_xy(src_data, src_shape, n, c, y, x);
+    }
+  }
+}
+
+
+template <typename Dtype>
+void DetectNetTransformationLayer<Dtype>::Forward_gpu(
+    const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+  const Dtype* bottom_data = bottom[0]->gpu_data();
+  Dtype* top_data = top[0]->mutable_gpu_data();
+  AugmentSelection* aug_data = reinterpret_cast<AugmentSelection*>(
+      gpu_workspace_augmentations_.data());
+  Dtype* tmp_data = reinterpret_cast<Dtype*>(
+      gpu_workspace_tmpdata_.data());
+
+  const uint4 bottom_shape = make_uint4(
+      bottom[0]->shape(3),   // x = W
+      bottom[0]->shape(2),   // y = H
+      bottom[0]->shape(1),   // z = C
+      bottom[0]->shape(0));  // w = N
+  const int bottom_count = bottom[0]->count();
+  const int bottom_pixels = bottom_shape.x * bottom_shape.y * bottom_shape.w;
+  const uint4 top_shape = make_uint4(
+      top[0]->shape(3),   // x = W
+      top[0]->shape(2),   // y = H
+      top[0]->shape(1),   // z = C
+      top[0]->shape(0));  // w = N
+  const int top_count = top[0]->count();
+  const int top_pixels = top_shape.x * top_shape.y * top_shape.w;
+
+  // Get current stream
+  int device;
+  CUDA_CHECK(cudaGetDevice(&device));
+  cudaStream_t stream = GPUMemory::device_stream(device);
+
+  // Make augmentation selections for each image
+  vector<AugmentSelection> augmentations;
+  for (int i = 0; i < bottom_shape.w; i++) {
+    augmentations.push_back(get_augmentations(
+        cv::Point(bottom_shape.x, bottom_shape.y)));
+  }
+  // Copy augmentation selections to GPU
+  size_t aug_data_sz = sizeof(AugmentSelection) * augmentations.size();
+  caffe_gpu_memcpy(aug_data_sz, &augmentations[0], aug_data);
+
+
+  // Color transformations
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  color_transformations<<<CAFFE_GET_BLOCKS(bottom_pixels),
+    CAFFE_CUDA_NUM_THREADS>>>(bottom_data, tmp_data, bottom_shape, aug_data);
+
+  // Mean subtraction
+  if (t_param_.has_mean_file()) {
+    // NOLINT_NEXT_LINE(whitespace/operators)
+    pixel_mean_subtraction<<<CAFFE_GET_BLOCKS(bottom_pixels),
+      CAFFE_CUDA_NUM_THREADS>>>(tmp_data, mean_blob_.gpu_data(), bottom_shape);
+  } else if (t_param_.mean_value_size() != 0) {
+    CHECK_EQ(bottom_shape.z, 3) << "Data must have 3 channels when "
+      "using transform_param.mean_value.";
+    // NOLINT_NEXT_LINE(whitespace/operators)
+    channel_mean_subtraction<<<CAFFE_GET_BLOCKS(bottom_pixels),
+      CAFFE_CUDA_NUM_THREADS>>>(tmp_data, bottom_shape,
+        mean_values_[0] * UINT8_MAX,
+        mean_values_[1] * UINT8_MAX,
+        mean_values_[2] * UINT8_MAX);
+  }
+
+  // Spatial transformations
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  spatial_transformations<<<CAFFE_GET_BLOCKS(top_pixels),
+    CAFFE_CUDA_NUM_THREADS>>>(tmp_data, bottom_shape, aug_data,
+        top_data, top_shape);
+
+  // Use CPU to transform labels
+  const vector<vector<BboxLabel> > list_list_bboxes = blobToLabels(*bottom[1]);
+  for (size_t i = 0; i < bottom[1]->num(); i++) {
+    const vector<BboxLabel>& list_bboxes = list_list_bboxes[i];
+    Dtype* output_label = &top[1]->mutable_cpu_data()[
+      top[1]->offset(i, 0, 0, 0)
+      ];
+    transform_label_cpu(list_bboxes, output_label, augmentations[i],
+        cv::Size(bottom_shape.x, bottom_shape.y));
+  }
+}
+
+
+INSTANTIATE_LAYER_GPU_FUNCS(DetectNetTransformationLayer);
+
+
+}  // namespace caffe

--- a/src/caffe/layers/l1_loss_layer.cpp
+++ b/src/caffe/layers/l1_loss_layer.cpp
@@ -1,0 +1,59 @@
+#include "caffe/layers/l1_loss_layer.hpp"
+
+#include <vector>
+
+#include "caffe/layer.hpp"
+#include "caffe/util/io.hpp"
+#include "caffe/util/math_functions.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void L1LossLayer<Dtype>::Reshape(
+  const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+  LossLayer<Dtype>::Reshape(bottom, top);
+  CHECK_EQ(bottom[0]->count(1), bottom[1]->count(1))
+      << "Inputs must have the same dimension.";
+  diff_.ReshapeLike(*bottom[0]);
+  sign_.ReshapeLike(*bottom[0]);
+}
+
+
+template <typename Dtype>
+void L1LossLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+                                            const vector<Blob<Dtype>*>& top) {
+  int count = bottom[0]->count();
+  caffe_sub(
+      count,
+      bottom[0]->cpu_data(),
+      bottom[1]->cpu_data(),
+      diff_.mutable_cpu_data());
+  caffe_cpu_sign(count, diff_.cpu_data(), sign_.mutable_cpu_data());
+  Dtype abs_sum = caffe_cpu_asum(count, diff_.cpu_data());
+  Dtype loss = abs_sum / bottom[0]->num();
+  top[0]->mutable_cpu_data()[0] = loss;
+}
+
+
+template <typename Dtype>
+void L1LossLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
+    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+  for (int i = 0; i < 2; ++i) {
+    if (propagate_down[i]) {
+      const Dtype sign = (i == 0) ? 1 : -1;
+      const Dtype alpha = sign * top[0]->cpu_diff()[0] / bottom[i]->num();
+      caffe_cpu_axpby(
+          bottom[i]->count(),              // count
+          alpha,                              // alpha
+          sign_.cpu_data(),                   // a
+          Dtype(0),                           // beta
+          bottom[i]->mutable_cpu_diff());  // b
+    }
+  }
+}
+
+
+INSTANTIATE_CLASS(L1LossLayer);
+REGISTER_LAYER_CLASS(L1Loss);
+
+}  // namespace caffe

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -407,6 +407,10 @@ message LayerParameter {
   optional WindowDataParameter window_data_param = 129;
   optional MILDataParameter mil_data_param = 0x004d4944; //"MID"
   optional MILParameter mil_param = 0x004d494c; //"MIL"
+
+  // NVIDIA PARAMETERS (Start with 68 because NV is 68 on an old-style phone)
+  optional DetectNetGroundTruthParameter detectnet_groundtruth_param = 6801;
+  optional DetectNetAugmentationParameter detectnet_augmentation_param = 6802;
 }
 
 // Message that stores parameters used to apply transformation
@@ -430,6 +434,79 @@ message TransformationParameter {
   optional bool force_color = 6 [default = false];
   // Force the decoded image to have 1 color channels.
   optional bool force_gray = 7 [default = false];
+}
+// Message that stores parameters used to create gridbox ground truth
+message DetectNetGroundTruthParameter {
+  // stride of gridbox with respect to image size
+  optional uint32 stride = 1 [default = 4];
+  // coverage region scale with respect to bounding box size
+  optional float scale_cvg = 2 [default = 0.5];
+  enum GridboxType {
+    GRIDBOX_MAX = 0;
+    GRIDBOX_MIN = 1;
+  }
+  // determines coverage region's maximum and minimum dimensions
+  optional GridboxType gridbox_type = 3 [default = GRIDBOX_MAX];
+  // if gridbox_type is equal to GRIDBOX_MAX, the maximum size a given coverage
+  //  region may take.
+  optional uint32 max_cvg_len = 4 [default = 50];
+  // if gridbox_type is equal to GRIDBOX_MIN, the minimum size a given coverage
+  //  region may take.
+  optional uint32 min_cvg_len = 5 [default = 50];
+  enum CoverageType {
+    RECTANGULAR = 0;
+  }
+  // shape of the coverage geometry.
+  optional CoverageType coverage_type = 7 [default = RECTANGULAR];
+  // Size that incoming images are cropped / scaled to during training / test
+  //  time. The network will only see images of this size.
+  optional uint32 image_size_x = 8 [default = 1248];
+  optional uint32 image_size_y = 9 [default = 384];
+  // coverage proportional to the size of the gridbox region overlapping the
+  // normalize object coverage by the size of the object
+  optional bool obj_norm = 11 [default = false];
+  // crop incoming bboxes such that their bounds remain inside the gridbox.
+  optional bool crop_bboxes = 12 [default = true];
+  // Integer and target index of classes to be included:
+  message ClassMapping {
+    required uint32 src = 1;
+    required uint32 dst = 2;
+  }
+  repeated ClassMapping object_class = 13;
+}
+
+// Message that stores parameters used to apply image and label augmentations
+// specific to NVDataLayer's online augmentation module
+message DetectNetAugmentationParameter {
+  // probability that a random crop of the training image will be taken at test
+  //  time. If image dimensions are less than input size and random cropping is
+  //  off, then the image will be scaled deterministically to the input size.
+  optional float crop_prob = 1 [default = 1.0];
+  // number of pixels to shift the image by. If cropping is enabled, this number
+  //  is added to the range of possible crop offset values.
+  optional uint32 shift_x = 2 [default = 0];
+  optional uint32 shift_y = 3 [default = 0];
+  // probability that the training image will be scaled at test time. 0 turns
+  //  scale augmentation off.
+  optional float scale_prob = 4 [default = 0.33];
+  // minimum and maximum scaling factor. 1.0 implies no scaling.
+  optional float scale_min = 5 [default = 0.7];
+  optional float scale_max = 6 [default = 1.0];
+  // probability that image will be flipped across the Y axis. 0 turns flip
+  //  augmentation off.
+  optional float flip_prob = 7 [default = 0.33];
+  // maximum angle in degrees (in both directions) image may be rotated. 0 turns
+  //  rotation augmentation off.
+  optional float rotation_prob = 8 [default = 0.33];
+  optional float max_rotate_degree = 9 [default = 1.0];
+  // maximum rotation of hue in degrees (in both directions). 0 turns hue
+  //  augmentation off.
+  optional float hue_rotation_prob = 10 [default = 0.33];
+  optional float hue_rotation = 11 [default = 15];
+  // maximum desaturation parameter. 1.0 may convert RGB to luminance. 0 turns
+  //  desaturation augmentation off.
+  optional float desaturation_prob = 12 [default = 0.33];
+  optional float desaturation_max = 13 [default = 0.5];
 }
 
 // Message that stores parameters shared by loss layers

--- a/src/caffe/test/test_detectnet_transform.cpp
+++ b/src/caffe/test/test_detectnet_transform.cpp
@@ -1,0 +1,388 @@
+#ifdef USE_OPENCV
+
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "caffe/blob.hpp"
+#include "caffe/common.hpp"
+#include "caffe/filler.hpp"
+#include "caffe/layers/detectnet_transform_layer.hpp"
+
+#include "caffe/test/test_caffe_main.hpp"
+
+namespace caffe {
+
+#define BACKGROUND_VALUE 0
+
+template <typename TypeParam>
+class DetectNetTransformationLayerTest : public MultiDeviceTest<TypeParam> {
+  typedef typename TypeParam::Dtype Dtype;
+
+ protected:
+  DetectNetTransformationLayerTest()
+      : blob_bottom_data_(new Blob<Dtype>()),
+        blob_bottom_label_(new Blob<Dtype>()),
+        blob_top_data_(new Blob<Dtype>()),
+        blob_top_label_(new Blob<Dtype>()) {
+    blob_bottom_vec_.push_back(blob_bottom_data_);
+    blob_bottom_vec_.push_back(blob_bottom_label_);
+    blob_top_vec_.push_back(blob_top_data_);
+    blob_top_vec_.push_back(blob_top_label_);
+
+    this->fillDataBlob();
+    this->fillLabelBlob();
+  }
+  virtual ~DetectNetTransformationLayerTest() {
+      delete blob_bottom_data_;
+      delete blob_bottom_label_;
+      delete blob_top_data_;
+      delete blob_top_label_;
+  }
+
+  // Fill data blob with filler
+  void fillDataBlob(Filler<Dtype>* filler = NULL) {
+    blob_bottom_data_->Reshape(1, 3, 32, 32);
+    if (filler != NULL) {
+      filler->Fill(blob_bottom_data_);
+    } else {
+      // default to uniform noise in [0-255]
+      FillerParameter filler_param;
+      filler_param.set_min(0);
+      filler_param.set_max(255);
+      UniformFiller<Dtype> default_filler(filler_param);
+      default_filler.Fill(blob_bottom_data_);
+    }
+  }
+
+  // Set label to detect one object
+  void fillLabelBlob() {
+    blob_bottom_label_->Reshape(1, 1, 2, 16);
+    Dtype* label_data = blob_bottom_label_->mutable_cpu_data();
+    int d = blob_bottom_label_->shape()[3];
+    label_data[0*d+0] = 1;  // num rows
+    label_data[0*d+1] = blob_bottom_label_->shape()[3];  // num cols
+
+    label_data[1*d+0] = 0;  // bbox topleft x
+    label_data[1*d+1] = 0;  // bbox topleft y
+    label_data[1*d+2] = blob_bottom_data_->width()/2;  // bbox width
+    label_data[1*d+3] = blob_bottom_data_->height()/2;  // bbox height
+    label_data[1*d+4] = 0;  // alpha angle
+    label_data[1*d+5] = 1;  // class number
+    label_data[1*d+6] = 0;  // bbox.scenario()
+    label_data[1*d+7] = 0;  // Y axis rotation
+    label_data[1*d+8] = 0;  // truncation
+    label_data[1*d+9] = 0;  // occlusion
+    label_data[1*d+10] = 0;  // object length
+    label_data[1*d+11] = 0;  // object width
+    label_data[1*d+12] = 0;  // object height
+    label_data[1*d+13] = 0;  // location_x
+    label_data[1*d+14] = 0;  // location_y
+    label_data[1*d+15] = 0;  // location_z
+  }
+
+  // returns a layer parameter with all augmentations turned off
+  LayerParameter layerParamNoAug() {
+    LayerParameter layer_param;
+
+    DetectNetGroundTruthParameter* groundtruth_param =
+        layer_param.mutable_detectnet_groundtruth_param();
+    // set output size
+    groundtruth_param->set_image_size_x(this->blob_bottom_data_->width());
+    groundtruth_param->set_image_size_y(this->blob_bottom_data_->height());
+
+    DetectNetAugmentationParameter* augmentation_param =
+        layer_param.mutable_detectnet_augmentation_param();
+    // Turn off all augmentations
+    augmentation_param->set_hue_rotation_prob(0);
+    augmentation_param->set_desaturation_prob(0);
+    augmentation_param->set_flip_prob(0);
+    augmentation_param->set_scale_prob(0);
+    augmentation_param->set_rotation_prob(0);
+    augmentation_param->set_crop_prob(0);
+
+    return layer_param;
+  }
+
+  Blob<Dtype>* const blob_bottom_data_;
+  Blob<Dtype>* const blob_bottom_label_;
+  Blob<Dtype>* const blob_top_data_;
+  Blob<Dtype>* const blob_top_label_;
+  vector<Blob<Dtype>*> blob_bottom_vec_;
+  vector<Blob<Dtype>*> blob_top_vec_;
+};
+
+TYPED_TEST_CASE(DetectNetTransformationLayerTest, TestDtypesAndDevices);
+
+TYPED_TEST(DetectNetTransformationLayerTest, TestSetup) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param = this->layerParamNoAug();
+  const DetectNetGroundTruthParameter groundtruth_param =
+    layer_param.detectnet_groundtruth_param();
+  DetectNetTransformationLayer<Dtype> layer(layer_param);
+  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  EXPECT_EQ(this->blob_top_data_->shape(), this->blob_bottom_data_->shape());
+  EXPECT_EQ(this->blob_top_label_->shape()[0],
+      this->blob_bottom_label_->shape()[0]);
+  EXPECT_GE(this->blob_top_label_->shape()[1], 9);
+  EXPECT_EQ(this->blob_top_label_->shape()[2],
+      this->blob_bottom_data_->shape()[2]/groundtruth_param.stride());
+  EXPECT_EQ(this->blob_top_label_->shape()[3],
+      this->blob_bottom_data_->shape()[3]/groundtruth_param.stride());
+}
+
+TYPED_TEST(DetectNetTransformationLayerTest, TestNoAugmentation) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param = this->layerParamNoAug();
+  DetectNetTransformationLayer<Dtype> layer(layer_param);
+  layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+  // Check that data is unchanged
+  for (int i = 0; i < this->blob_bottom_data_->count(); i++) {
+    EXPECT_FLOAT_EQ(this->blob_top_data_->cpu_data()[i],
+        this->blob_bottom_data_->cpu_data()[i]);
+  }
+}
+
+TYPED_TEST(DetectNetTransformationLayerTest, TestAllAugmentation) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param = this->layerParamNoAug();
+  DetectNetAugmentationParameter* augmentation_param =
+      layer_param.mutable_detectnet_augmentation_param();
+  // Turn off all augmentations
+  augmentation_param->set_hue_rotation_prob(1);
+  augmentation_param->set_desaturation_prob(1);
+  augmentation_param->set_flip_prob(1);
+  augmentation_param->set_scale_prob(1);
+  augmentation_param->set_rotation_prob(1);
+  augmentation_param->set_crop_prob(1);
+  DetectNetTransformationLayer<Dtype> layer(layer_param);
+  layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+  // nothing to test
+}
+
+
+TYPED_TEST(DetectNetTransformationLayerTest, TestDesaturation) {
+  typedef typename TypeParam::Dtype Dtype;
+  // make sure we don't get unlucky with a random saturation value of 0
+  Caffe::set_random_seed(1234);
+  LayerParameter layer_param = this->layerParamNoAug();
+  DetectNetAugmentationParameter* augmentation_param =
+      layer_param.mutable_detectnet_augmentation_param();
+  // turn on desaturation
+  augmentation_param->set_desaturation_prob(1);
+  augmentation_param->set_desaturation_max(1);
+  DetectNetTransformationLayer<Dtype> layer(layer_param);
+  layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+  if (this->blob_bottom_data_->channels() == 3) {
+    // Check that all pixels values are higher in value
+    const int ns = this->blob_bottom_data_->num();
+    const int cs = this->blob_bottom_data_->channels();
+    const int hs = this->blob_bottom_data_->height();
+    const int ws = this->blob_bottom_data_->width();
+    const Dtype* bottom_data = this->blob_bottom_data_->cpu_data();
+    const Dtype* top_data = this->blob_top_data_->cpu_data();
+    const Dtype eps = 1e-3;
+    for (int n = 0; n < ns; n++) {
+      for (int h = 0; h < hs; h++) {
+        for (int w = 0; w < ws; w++) {
+          const Dtype r1 = bottom_data[n*cs*hs*ws + 0*hs*ws + h*ws + w];
+          const Dtype g1 = bottom_data[n*cs*hs*ws + 1*hs*ws + h*ws + w];
+          const Dtype b1 = bottom_data[n*cs*hs*ws + 2*hs*ws + h*ws + w];
+          const Dtype r2 = top_data[n*cs*hs*ws + 0*hs*ws + h*ws + w];
+          const Dtype g2 = top_data[n*cs*hs*ws + 1*hs*ws + h*ws + w];
+          const Dtype b2 = top_data[n*cs*hs*ws + 2*hs*ws + h*ws + w];
+          EXPECT_GE(r2 + eps, r1);
+          EXPECT_GE(g2 + eps, g1);
+          EXPECT_GE(b2 + eps, b1);
+        }
+      }
+    }
+  }
+}
+
+TYPED_TEST(DetectNetTransformationLayerTest, TestHueRotation) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param = this->layerParamNoAug();
+  DetectNetAugmentationParameter* augmentation_param =
+      layer_param.mutable_detectnet_augmentation_param();
+  // turn on hue rotation
+  augmentation_param->set_hue_rotation_prob(1);
+  DetectNetTransformationLayer<Dtype> layer(layer_param);
+  layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+  // nothing to test
+}
+
+TYPED_TEST(DetectNetTransformationLayerTest, TestFlip) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param = this->layerParamNoAug();
+  DetectNetAugmentationParameter* augmentation_param =
+      layer_param.mutable_detectnet_augmentation_param();
+  // turn on flipping
+  augmentation_param->set_flip_prob(1);
+  DetectNetTransformationLayer<Dtype> layer(layer_param);
+  layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+  // Check that data is flipped
+  const int ns = this->blob_bottom_data_->num();
+  const int cs = this->blob_bottom_data_->channels();
+  const int hs = this->blob_bottom_data_->height();
+  const int ws = this->blob_bottom_data_->width();
+  for (int n = 0; n < ns; n++) {
+    for (int c = 0; c < cs; c++) {
+      for (int h = 0; h < hs; h++) {
+        for (int w = 0; w < ws; w++) {
+          EXPECT_FLOAT_EQ(
+              this->blob_top_data_->cpu_data()[n*cs*hs*ws + c*hs*ws + h*ws + w],
+              // NOLINT_NEXT_LINE(whitespace/line_length)
+              this->blob_bottom_data_->cpu_data()[n*cs*hs*ws + c*hs*ws + h*ws + (ws-w-1)]);
+        }
+      }
+    }
+  }
+}
+
+TYPED_TEST(DetectNetTransformationLayerTest, TestScaleDown) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param = this->layerParamNoAug();
+  DetectNetAugmentationParameter* augmentation_param =
+      layer_param.mutable_detectnet_augmentation_param();
+  // turn on scaling
+  augmentation_param->set_scale_prob(1);
+  augmentation_param->set_scale_min(0.5);
+  augmentation_param->set_scale_max(0.5);
+  DetectNetTransformationLayer<Dtype> layer(layer_param);
+  // fill with a constant
+  FillerParameter filler_param;
+  const Dtype DATA_VALUE = 10;
+  filler_param.set_value(DATA_VALUE);
+  ConstantFiller<Dtype> filler(filler_param);
+  this->fillDataBlob(&filler);
+  layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+  const int ns = this->blob_bottom_data_->num();
+  const int cs = this->blob_bottom_data_->channels();
+  const int hs = this->blob_bottom_data_->height();
+  const int ws = this->blob_bottom_data_->width();
+  for (int n = 0; n < ns; n++) {
+    for (int c = 0; c < cs; c++) {
+      // corners should be background
+      EXPECT_FLOAT_EQ(BACKGROUND_VALUE,
+          this->blob_top_data_->cpu_data()[n*cs*hs*ws + c*hs*ws]);
+      EXPECT_FLOAT_EQ(BACKGROUND_VALUE,
+          this->blob_top_data_->cpu_data()[n*cs*hs*ws + c*hs*ws + ws-1]);
+      EXPECT_FLOAT_EQ(BACKGROUND_VALUE,
+          this->blob_top_data_->cpu_data()[n*cs*hs*ws + c*hs*ws + (hs-1)*ws]);
+      EXPECT_FLOAT_EQ(BACKGROUND_VALUE,
+          // NOLINT_NEXT_LINE(whitespace/line_length)
+          this->blob_top_data_->cpu_data()[n*cs*hs*ws + c*hs*ws + (hs-1)*ws + ws-1]);
+      // center should be data
+      EXPECT_FLOAT_EQ(DATA_VALUE,
+          // NOLINT_NEXT_LINE(whitespace/line_length)
+          this->blob_top_data_->cpu_data()[n*cs*hs*ws + c*hs*ws + (hs/2)*ws + ws/2]);
+    }
+  }
+}
+
+TYPED_TEST(DetectNetTransformationLayerTest, TestScaleUp) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param = this->layerParamNoAug();
+  DetectNetAugmentationParameter* augmentation_param =
+      layer_param.mutable_detectnet_augmentation_param();
+  // turn on scaling
+  augmentation_param->set_scale_prob(1);
+  augmentation_param->set_scale_min(2);
+  augmentation_param->set_scale_max(2);
+  DetectNetTransformationLayer<Dtype> layer(layer_param);
+  // fill with a constant
+  FillerParameter filler_param;
+  const Dtype DATA_VALUE = 10;
+  filler_param.set_value(DATA_VALUE);
+  ConstantFiller<Dtype> filler(filler_param);
+  this->fillDataBlob(&filler);
+  layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+  // check results
+  const int ns = this->blob_bottom_data_->num();
+  const int cs = this->blob_bottom_data_->channels();
+  const int hs = this->blob_bottom_data_->height();
+  const int ws = this->blob_bottom_data_->width();
+  for (int n = 0; n < ns; n++) {
+    for (int c = 0; c < cs; c++) {
+      // corners should be data
+      EXPECT_FLOAT_EQ(DATA_VALUE,
+          this->blob_top_data_->cpu_data()[n*cs*hs*ws + c*hs*ws]);
+      EXPECT_FLOAT_EQ(DATA_VALUE,
+          this->blob_top_data_->cpu_data()[n*cs*hs*ws + c*hs*ws + ws-1]);
+      EXPECT_FLOAT_EQ(DATA_VALUE,
+          this->blob_top_data_->cpu_data()[n*cs*hs*ws + c*hs*ws + (hs-1)*ws]);
+      EXPECT_FLOAT_EQ(DATA_VALUE,
+          // NOLINT_NEXT_LINE(whitespace/line_length)
+          this->blob_top_data_->cpu_data()[n*cs*hs*ws + c*hs*ws + (hs-1)*ws + ws-1]);
+      // center should be data
+      EXPECT_FLOAT_EQ(DATA_VALUE,
+          // NOLINT_NEXT_LINE(whitespace/line_length)
+          this->blob_top_data_->cpu_data()[n*cs*hs*ws + c*hs*ws + (hs/2)*ws + ws/2]);
+    }
+  }
+}
+
+TYPED_TEST(DetectNetTransformationLayerTest, TestRotation) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param = this->layerParamNoAug();
+  DetectNetAugmentationParameter* augmentation_param =
+      layer_param.mutable_detectnet_augmentation_param();
+  // turn on rotation
+  augmentation_param->set_rotation_prob(1);
+  augmentation_param->set_max_rotate_degree(80);
+  // downscale by a bit
+  augmentation_param->set_scale_prob(1);
+  augmentation_param->set_scale_min(0.85);
+  augmentation_param->set_scale_max(0.85);
+  DetectNetTransformationLayer<Dtype> layer(layer_param);
+  // fill with a constant
+  FillerParameter filler_param;
+  const Dtype DATA_VALUE = 10;
+  filler_param.set_value(DATA_VALUE);
+  ConstantFiller<Dtype> filler(filler_param);
+  this->fillDataBlob(&filler);
+  layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+  // check results
+  const int ns = this->blob_bottom_data_->num();
+  const int cs = this->blob_bottom_data_->channels();
+  const int hs = this->blob_bottom_data_->height();
+  const int ws = this->blob_bottom_data_->width();
+  for (int n = 0; n < ns; n++) {
+    for (int c = 0; c < cs; c++) {
+      // corners should be background
+      EXPECT_FLOAT_EQ(BACKGROUND_VALUE,
+          this->blob_top_data_->cpu_data()[n*cs*hs*ws + c*hs*ws]);
+      EXPECT_FLOAT_EQ(BACKGROUND_VALUE,
+          this->blob_top_data_->cpu_data()[n*cs*hs*ws + c*hs*ws + ws-1]);
+      EXPECT_FLOAT_EQ(BACKGROUND_VALUE,
+          this->blob_top_data_->cpu_data()[n*cs*hs*ws + c*hs*ws + (hs-1)*ws]);
+      EXPECT_FLOAT_EQ(BACKGROUND_VALUE,
+          // NOLINT_NEXT_LINE(whitespace/line_length)
+          this->blob_top_data_->cpu_data()[n*cs*hs*ws + c*hs*ws + (hs-1)*ws + ws-1]);
+      // center should be data
+      EXPECT_FLOAT_EQ(DATA_VALUE,
+          // NOLINT_NEXT_LINE(whitespace/line_length)
+          this->blob_top_data_->cpu_data()[n*cs*hs*ws + c*hs*ws + (hs/2)*ws + ws/2]);
+    }
+  }
+}
+
+TYPED_TEST(DetectNetTransformationLayerTest, TestCrop) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param = this->layerParamNoAug();
+  DetectNetAugmentationParameter* augmentation_param =
+      layer_param.mutable_detectnet_augmentation_param();
+  // turn on cropping
+  augmentation_param->set_crop_prob(1);
+  augmentation_param->set_shift_x(this->blob_bottom_data_->width());
+  augmentation_param->set_shift_y(this->blob_bottom_data_->height());
+  DetectNetTransformationLayer<Dtype> layer(layer_param);
+  layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+  // nothing to test
+}
+
+
+}  // namespace caffe
+
+#endif  // USE_OPENCV

--- a/src/caffe/util/detectnet_coverage_rectangular.cpp
+++ b/src/caffe/util/detectnet_coverage_rectangular.cpp
@@ -1,0 +1,373 @@
+#ifdef USE_OPENCV
+
+#include <opencv2/core/core.hpp>
+#include <opencv2/opencv.hpp>
+
+#include <boost/array.hpp>
+#include <boost/foreach.hpp>
+#include <boost/ref.hpp>
+#include <boost/scoped_ptr.hpp>
+#include <boost/static_assert.hpp>
+
+#include <algorithm>
+#include <vector>
+
+#include "caffe/common.hpp"
+#include "caffe/util/detectnet_coverage.hpp"
+
+using namespace cv;  // NOLINT(build/namespaces)
+using boost::array;
+using boost::scoped_ptr;
+using boost::reference_wrapper;
+using boost::ref;
+
+#define foreach_ BOOST_FOREACH
+#define TRANSFORMED_LABEL_AT(coverageClass, _x, _y, _z) \
+transformedLabels[(coverageClass)->gridROI_.area() * (_z) \
+                + (_y) * (coverageClass)->gridROI_.width \
+                + (_x)]
+
+namespace caffe {
+
+
+template<typename Dtype>
+void zeroCoverage(vector<reference_wrapper<Dtype> >* coverages) {
+  foreach_(boost::reference_wrapper<Dtype>& coverage, *coverages) {
+    coverage.get() = 0.0;
+  }
+}
+
+
+template<typename Dtype>
+CoverageGenerator<Dtype>::CoverageGenerator(
+    const DetectNetGroundTruthParameter& param
+) : param_(param),
+    imageROI_(0, 0, (Dtype) param.image_size_x(), (Dtype) param.image_size_y()),
+    gridROI_(
+      imageROI_.tl()   * (Dtype)(1.0 / param.stride()),
+      imageROI_.size() * (Dtype)(1.0 / param.stride())),
+    gridBoxArea_(this->param_.stride() * this->param_.stride()),
+    minObjNorm_(this->param_.obj_norm() ? 0.0 : 1.0),
+    labels_(this->assignLabels(param)),
+    label_size_(findNumLabels(labels_) + TRANSFORMED_LABEL_SIZE) {}
+
+
+template<typename Dtype>
+CoverageGenerator<Dtype>* CoverageGenerator<Dtype>::create(
+    const DetectNetGroundTruthParameter& param
+) {
+  switch (param.coverage_type()) {
+    default:
+      LOG(WARNING)
+          << "Unknown coverage type specified \""
+          << param.coverage_type()
+          << "\", defaulting to rectangular";
+    case DetectNetGroundTruthParameter_CoverageType_RECTANGULAR:
+      return new RectangularCoverageGenerator<Dtype>(param);
+  }
+}
+
+
+template<typename Dtype>
+size_t CoverageGenerator<Dtype>::findNumLabels(
+    const LabelMap& labels
+) const {
+  size_t max_keyvalue = 0;
+  foreach_(const LabelMap::value_type& keypair, labels) {
+    max_keyvalue = std::max(max_keyvalue, keypair.second);
+  }
+  return max_keyvalue + 1;
+}
+
+
+template<typename Dtype>
+typename CoverageGenerator<Dtype>::LabelMap
+CoverageGenerator<Dtype>::assignLabels(
+    const DetectNetGroundTruthParameter& g_param_
+) const {
+  LabelMap result;
+  for (size_t iClass = 0; iClass != g_param_.object_class_size(); ++iClass) {
+    const DetectNetGroundTruthParameter_ClassMapping& mapping =
+        g_param_.object_class(iClass);
+    result[mapping.src()] = mapping.dst();
+  }
+  // if labels is empty, assign a simple mapping so we always have at least one
+  //  class. 1 is a magic number specific to Kitti, implying the car class. We
+  //  do this to maintain backward compatibility with singleclass.
+  if (result.empty()) {
+    result[1] = 0;
+  }
+  return result;
+}
+
+
+template<typename Dtype>
+vector<typename CoverageGenerator<Dtype>::BboxLabel>
+CoverageGenerator<Dtype>::pruneBboxes(
+    const vector<BboxLabel>& bboxList
+) const {
+  vector<BboxLabel> result; result.reserve(bboxList.size());
+
+  foreach_(BboxLabel cLabel, bboxList) {
+    // crop bounding boxes to the dimensions of the screen:
+    if (this->param_.crop_bboxes()) {
+      // truncated bbox is the union of bounding box and screen rectangle, and
+      //  is always smaller than cLabel.bbox:
+      Rectv croppedBbox = cLabel.bbox & this->imageROI_;
+      // truncation is the area of the intersection over the whole:
+      Dtype truncation = 1.0 - std::max(cLabel.truncated, (Dtype)0.0);
+      truncation *=
+          croppedBbox.area() /
+          std::max(cLabel.bbox.area(), (Dtype)FLT_EPSILON);
+      // reset cLabel
+      cLabel.truncated = std::max(0.0, std::min(1.0, 1.0 - truncation));
+      cLabel.bbox = croppedBbox;
+    }
+
+    // exclude all labels which are not of the classes we care about:
+    if (labels_.count(size_t(cLabel.classNumber)) == 0) { continue; }
+
+    // exclude bounding boxes which don't exist in the scene at all:
+    if (cLabel.bbox.area() < FLT_EPSILON) { continue; }
+
+    result.push_back(cLabel);
+  }
+
+  return result;
+}
+
+
+template<typename Dtype>
+Scalar CoverageGenerator<Dtype>::bboxToColor(
+    const Point2i& tl,
+    const Point2i& br
+) const {
+  // TODO: is there an array of these colors elsewhere?
+  //  Exclude green, as that's the bounding box color.
+  static const array<Scalar, 18> colors = {{
+    Scalar(255, 0, 0),      Scalar(0, 0, 255),
+    Scalar(255, 255, 0),    Scalar(255, 0, 255),
+    Scalar(0, 255, 255),    Scalar(255, 127, 0),
+    Scalar(255, 0, 127),    Scalar(0, 255, 127),
+    Scalar(127, 255, 0),    Scalar(127, 0, 255),
+    Scalar(0, 127, 255),    Scalar(127, 255, 255),
+    Scalar(255, 127, 255),  Scalar(255, 255, 127),
+    Scalar(127, 127, 255),  Scalar(127, 255, 127),
+    Scalar(255, 127, 127),  Scalar(255, 255, 255)
+  }};
+
+  size_t iColor = ((((tl.x) * 1000 + tl.y)*1000 + br.x)*1000 + br.y);
+
+  return colors[iColor % colors.size()];
+}
+
+template<typename Dtype>
+void CoverageGenerator<Dtype>::clearLabel(Dtype* transformedLabels) const {
+  // fill all labels with 0's:
+  std::fill(
+      transformedLabels + gridROI_.area() * 0,
+      transformedLabels + gridROI_.area() * label_size_,
+      (Dtype) 0.0);
+}
+
+
+template <typename Dtype>
+typename CoverageGenerator<Dtype>::Rectv
+CoverageGenerator<Dtype>::coverageBoundingBox(const Rectv& boundingBox) const {
+  // find the center of the bbox as the midpoint between its top-left and
+  //  bottom-right points:
+  Point2v center = (boundingBox.tl() + boundingBox.br()) * 0.5;
+
+  // shrink coverage region by a percentage of the bounding box's size:
+  Size2v shrunkSize = boundingBox.size() * (Dtype)this->param_.scale_cvg();
+
+  switch (param_.gridbox_type()) {
+    // gridbox_min: ensure coverage region is no larger than the size of the
+    //  bounding box, but no smaller than a certain area in # of pixels
+    case DetectNetGroundTruthParameter_GridboxType_GRIDBOX_MIN:
+    {
+      Dtype min_cvg_len = this->param_.min_cvg_len();
+      shrunkSize.width = min(
+          boundingBox.width,
+          max(min_cvg_len, shrunkSize.width));
+      shrunkSize.height = min(
+          boundingBox.height,
+          max(min_cvg_len, shrunkSize.height));
+      break;
+    }
+    // gridbox_max: ensure coverage region is no smaller than a certain area in
+    //  # of pixels
+    case DetectNetGroundTruthParameter_GridboxType_GRIDBOX_MAX:
+    {
+      Dtype max_cvg_len = this->param_.max_cvg_len();
+      shrunkSize.width = min(max_cvg_len, shrunkSize.width);
+      shrunkSize.height = min(max_cvg_len, shrunkSize.height);
+      break;
+    }
+  }
+
+  // create a coverage region which defines the above shrunken size, centered
+  //  at the center of the bounding box:
+  Rectv coverage(
+      (center + Point2v(shrunkSize * (Dtype)0.5)),
+      (center - Point2v(shrunkSize * (Dtype)0.5)));
+
+  return coverage;
+}
+
+template<typename Dtype>
+Rect CoverageGenerator<Dtype>::imageRectToGridRect(const Rectv& area) const {
+  float stride = param_.stride();
+
+  // define a truncated rectangle which encompasses all gridspaces covered by
+  //  this bounding box:
+  Point tl(floor(area.tl().x / stride), floor(area.tl().y / stride));
+  Point br(ceil(area.br().x / stride), ceil(area.br().y / stride));
+  Rect g_area(tl, br);
+
+  // bound truncated rectangle by size of the gridbox area:
+  g_area &= gridROI_;
+
+  return g_area;
+}
+
+
+BOOST_STATIC_ASSERT(CoverageGenerator<float>::TRANSFORMED_LABEL_SIZE == 8);
+
+template<typename Dtype>
+TransformedLabel_<Dtype>::TransformedLabel_(
+    const CoverageGenerator<Dtype>& cgen,
+    Dtype* transformedLabels,
+    size_t g_x,
+    size_t g_y
+):  // foreground:
+    foreground(TRANSFORMED_LABEL_AT(&cgen, g_x, g_y, 0)),
+    // top left corner x,y:
+    topLeft_x(TRANSFORMED_LABEL_AT(&cgen, g_x, g_y, 1)),
+    topLeft_y(TRANSFORMED_LABEL_AT(&cgen, g_x, g_y, 2)),
+    // bottom right corner x,y:
+    bottomRight_x(TRANSFORMED_LABEL_AT(&cgen, g_x, g_y, 3)),
+    bottomRight_y(TRANSFORMED_LABEL_AT(&cgen, g_x, g_y, 4)),
+    // inverse size:
+    dimension_w(TRANSFORMED_LABEL_AT(&cgen, g_x, g_y, 5)),
+    dimension_h(TRANSFORMED_LABEL_AT(&cgen, g_x, g_y, 6)),
+    // obj_norm
+    obj_norm(TRANSFORMED_LABEL_AT(&cgen, g_x, g_y, 7)),
+    coverages() {
+  size_t coverageDimensions =
+      cgen.label_size_ - CoverageGenerator<Dtype>::TRANSFORMED_LABEL_SIZE;
+  coverages.reserve(coverageDimensions);
+  for (size_t iCoverage = 0;
+      iCoverage != coverageDimensions;
+      ++iCoverage) {
+    Dtype& coverage = TRANSFORMED_LABEL_AT(
+        &cgen,
+        g_x,
+        g_y,
+        CoverageGenerator<Dtype>::TRANSFORMED_LABEL_SIZE + iCoverage);
+
+    coverages.push_back(boost::ref(coverage));
+  }
+}
+
+
+template <typename Dtype>
+TransformedLabel_<Dtype> CoverageGenerator<Dtype>::transformedLabelAt(
+    Dtype* transformedLabels,
+    size_t g_x,
+    size_t g_y
+) const {
+  return TransformedLabel_<Dtype>(*this, transformedLabels, g_x, g_y);
+}
+
+template<typename Dtype>
+Dtype CoverageGenerator<Dtype>::objectNormValue(
+    const CoverageRegion& coverageRegion
+) const {
+  return this->gridBoxArea_ / coverageRegion.area();
+}
+
+
+template <typename Dtype>
+void CoverageGenerator<Dtype>::generate(
+    Dtype* transformedLabels,
+    const vector <BboxLabel>& _bboxList
+) const {
+  // ignore all label types we don't care about:
+  const vector<BboxLabel> bboxList(this->pruneBboxes(_bboxList));
+
+  // clear out transformed_label, things may remain inside from the last batch
+  this->clearLabel(transformedLabels);
+
+  // foreach bbox in list:
+  foreach_(const BboxLabel& label, bboxList) {
+    Rectv bbox(label.bbox);
+
+    // Define the area in which we intend to mark as containing an object to
+    //  the network:
+    Rectv coverage(this->coverageBoundingBox(bbox));
+
+    // coverage region is implementation specific and defined by extending
+    //  classes, but must fit within coverage Rectf:
+    scoped_ptr<CoverageRegion> coverageRegion(
+        this->coverageRegion(coverage));
+    Dtype dObjNormValue = objectNormValue(*coverageRegion);
+
+    // This Rect includes all gridspaces which overlap the coverage rectangle:
+    Rect g_coverage(this->imageRectToGridRect(coverage));
+
+    for (size_t g_y = g_coverage.tl().y; g_y < g_coverage.br().y; g_y++) {
+      for (size_t g_x = g_coverage.tl().x; g_x < g_coverage.br().x; g_x++) {
+        // the current gridbox:
+        Rectv gridBox(
+          Point2v(g_x, g_y) * (Dtype)this->param_.stride(),
+          Size2v(this->param_.stride(), this->param_.stride()));
+
+        // the amount of the gridbox covered by the coverage region:
+        Dtype cvgArea =
+            coverageRegion->intersectionArea(gridBox)
+          / this->gridBoxArea_;
+
+        TransformedLabel tLabel(this->transformedLabelAt(
+            transformedLabels,
+            g_x,
+            g_y));
+
+        if (cvgArea > FLT_EPSILON) {
+          zeroCoverage(&tLabel.coverages);
+          Dtype& tLabel_coverages =
+              tLabel.coverages[labels_.at(size_t(label.classNumber))];
+          // coverage (clamped from 0..1)
+          tLabel_coverages = 1.0;
+
+          // bbox
+          tLabel.topLeft_x     = bbox.tl().x - gridBox.tl().x;
+          tLabel.topLeft_y     = bbox.tl().y - gridBox.tl().y;
+          tLabel.bottomRight_x = bbox.br().x - gridBox.tl().x;
+          tLabel.bottomRight_y = bbox.br().y - gridBox.tl().y;
+
+          // bbox dimensions
+          tLabel.dimension_w = 1.0 / bbox.width;
+          tLabel.dimension_h = 1.0 / bbox.height;
+
+          // obj_norm
+          tLabel.obj_norm = std::max(this->minObjNorm_, dObjNormValue);
+
+          // foreground:
+          tLabel.foreground = 1.0;
+        }
+      }  // foreach x
+    }  // foreach y
+  }
+}
+
+
+INSTANTIATE_CLASS(CoverageGenerator);
+INSTANTIATE_CLASS(RectangularCoverageGenerator);
+
+}  // namespace caffe
+
+#undef TRANSFORMED_LABEL_AT
+#undef foreach_
+
+#endif  // USE_OPENCV

--- a/src/caffe/util/gpu_memory.cpp
+++ b/src/caffe/util/gpu_memory.cpp
@@ -1,0 +1,230 @@
+#ifndef CPU_ONLY
+#include <algorithm>
+#include <vector>
+#include "caffe/common.hpp"
+#include "caffe/util/gpu_memory.hpp"
+
+#include "cub/util_allocator.cuh"
+
+namespace caffe {
+using std::vector;
+
+const int GPUMemory::INVALID_DEVICE =
+    cub::CachingDeviceAllocator::INVALID_DEVICE_ORDINAL;
+const unsigned int GPUMemory::Manager::BIN_GROWTH = 2;
+const unsigned int GPUMemory::Manager::MIN_BIN = 6;
+const unsigned int GPUMemory::Manager::MAX_BIN = 22;
+const size_t GPUMemory::Manager::MAX_CACHED_BYTES = (size_t) -1;
+
+GPUMemory::Manager GPUMemory::mgr_;
+
+GPUMemory::Manager::Manager()
+  : mode_(CUDA_MALLOC), debug_(false), initialized_(false),
+    cub_allocator_(NULL) {}
+
+void GPUMemory::Manager::init(const vector<int>& gpus, Mode m, bool debug) {
+  if (initialized_) {
+    return;
+  }
+  bool debug_env = getenv("DEBUG_GPU_MEM") != 0;
+  debug_ = debug || debug_env;
+  if (gpus.size() <= 0) {
+    m = CUDA_MALLOC;
+  }
+  switch (m) {
+  case CUB_ALLOCATOR:
+    try {
+      // Just in case someone installed 'no cleanup' arena before
+      delete cub_allocator_;
+      cub_allocator_ = new cub::CachingDeviceAllocator(BIN_GROWTH, MIN_BIN,
+          MAX_BIN, MAX_CACHED_BYTES, true, debug_);
+    } catch (...) {
+    }
+    CHECK_NOTNULL(cub_allocator_);
+    for (int i = 0; i < gpus.size(); ++i) {
+      update_dev_info(gpus[i]);
+    }
+    break;
+  default:
+    break;
+  }
+  mode_ = m;
+  initialized_ = true;
+  DLOG(INFO) << "GPUMemory::Manager initialized with " << pool_name();
+}
+
+GPUMemory::Manager::~Manager() {
+  switch (mode_) {
+  case CUB_ALLOCATOR:
+    {
+      vector<cudaStream_t>::iterator it = device_streams_.begin();
+      while (it != device_streams_.end()) {
+        cudaStreamDestroy(*it++);
+      }
+    }
+    delete cub_allocator_;
+    break;
+  default:
+    break;
+  }
+}
+
+bool GPUMemory::Manager::try_allocate(void** ptr, size_t size, int device,
+    cudaStream_t stream) {
+  CHECK(initialized_) << "Create GPUMemory::Scope to initialize Memory Manager";
+  CHECK_NOTNULL(ptr);
+  cudaError_t status = cudaSuccess, last_err = cudaSuccess;
+  switch (mode_) {
+  case CUB_ALLOCATOR:
+    // Clean Cache & Retry logic is inside now
+    status = cub_allocator_->DeviceAllocate(device, ptr, size, stream);
+    // If there was a retry and it succeeded we get good status here but
+    // we need to clean up last error...
+    last_err = cudaGetLastError();
+    // ...and update the dev info if something was wrong
+    if (status != cudaSuccess || last_err != cudaSuccess) {
+      // If we know what particular device failed we update its info only
+      if (device > INVALID_DEVICE && device < dev_info_.size()) {
+        // only query devices that were initialized
+        if (dev_info_[device].total_) {
+          update_dev_info(device);
+          dev_info_[device].flush_count_++;
+        }
+      } else {
+        // Update them all otherwise
+        int cur_device;
+        CUDA_CHECK(cudaGetDevice(&cur_device));
+        // Refresh per-device saved values.
+        for (int i = 0; i < dev_info_.size(); ++i) {
+          // only query devices that were initialized
+          if (dev_info_[i].total_) {
+            update_dev_info(i);
+            // record which device caused cache flush
+            if (i == cur_device) {
+              dev_info_[i].flush_count_++;
+            }
+          }
+        }
+      }
+    }
+    break;
+  default:
+    status = cudaMalloc(ptr, size);
+    break;
+  }
+  return status == cudaSuccess;
+}
+
+void GPUMemory::Manager::deallocate(void* ptr, int device,
+    cudaStream_t stream) {
+  // allow for null pointer deallocation
+  if (!ptr) {
+    return;
+  }
+  switch (mode_) {
+  case CUB_ALLOCATOR:
+    {
+      int current_device;
+      cudaError_t status = cudaGetDevice(&current_device);
+      // Preventing dead lock while Caffe shutting down.
+      if (status != cudaErrorCudartUnloading) {
+        CUDA_CHECK(cub_allocator_->DeviceFree(device, ptr));
+      }
+    }
+    break;
+  default:
+    CUDA_CHECK(cudaFree(ptr));
+    break;
+  }
+}
+
+void GPUMemory::Manager::update_dev_info(int device) {
+  int initial_device;
+  CUDA_CHECK(cudaGetDevice(&initial_device));
+  if (device + 1 > dev_info_.size()) {
+    dev_info_.resize(device + 1);
+  }
+
+  CUDA_CHECK(cudaSetDevice(device));
+  cudaDeviceProp props;
+  CUDA_CHECK(cudaGetDeviceProperties(&props, device));
+  CUDA_CHECK(cudaMemGetInfo(&dev_info_[device].free_,
+      &dev_info_[device].total_));
+
+  DLOG(INFO) << "cudaGetDeviceProperties: Mem = " << props.totalGlobalMem;
+  DLOG(INFO) << "cudaMemGetInfo_[" << device << "]: Free="
+             << dev_info_[device].free_ << " Total="
+             << dev_info_[device].total_;
+
+  // Make sure we don't have more than total device memory.
+#ifdef _MSC_VER
+  dev_info_[device].total_ = min(props.totalGlobalMem,
+      dev_info_[device].total_);
+  dev_info_[device].free_ = min(dev_info_[device].total_,
+      dev_info_[device].free_);
+  CUDA_CHECK(cudaSetDevice(initial_device));
+#else
+  dev_info_[device].total_ = std::min(props.totalGlobalMem,
+      dev_info_[device].total_);
+  dev_info_[device].free_ = std::min(dev_info_[device].total_,
+      dev_info_[device].free_);
+  CUDA_CHECK(cudaSetDevice(initial_device));
+#endif
+}
+
+const char* GPUMemory::Manager::pool_name() const {
+  switch (mode_) {
+  case CUB_ALLOCATOR:
+    return "Caching (CUB) GPU Allocator";
+  default:
+    return "Plain CUDA GPU Allocator";
+  }
+}
+
+void GPUMemory::Manager::GetInfo(size_t* free_mem, size_t* total_mem) {
+  switch (mode_) {
+  case CUB_ALLOCATOR:
+    int cur_device;
+    CUDA_CHECK(cudaGetDevice(&cur_device));
+    *total_mem = dev_info_[cur_device].total_;
+    // Free memory is free GPU memory plus free cached memory in the pool.
+    *free_mem = dev_info_[cur_device].free_ +
+        cub_allocator_->cached_bytes[cur_device].free;
+    if (*free_mem > *total_mem) {  // sanity check
+      *free_mem = *total_mem;
+    }
+    break;
+  default:
+    CUDA_CHECK(cudaMemGetInfo(free_mem, total_mem));
+    break;
+  }
+}
+
+shared_ptr<GPUMemory::Workspace>
+GPUMemory::MultiWorkspace::current_workspace(int device) const {
+  if (device + 1 > workspaces_.size()) {
+    workspaces_.resize(device + 1);
+  }
+  shared_ptr<GPUMemory::Workspace>& ws = workspaces_[device];
+  if (!ws) {  // In case if --gpu=1,0
+    ws.reset(new GPUMemory::Workspace);
+  }
+  return ws;
+}
+
+cudaStream_t
+GPUMemory::Manager::device_stream(int device) {
+  if (device + 1 > device_streams_.size()) {
+    device_streams_.resize(device + 1);
+  }
+  cudaStream_t& stream = device_streams_[device];
+  if (!stream) {
+    // Here we assume that device is current.
+    CUDA_CHECK(cudaStreamCreate(&stream));
+  }
+  return stream;
+}
+
+}  // namespace caffe
+
+#endif  // CPU_ONLY

--- a/windows/caffe/caffe.vcxproj
+++ b/windows/caffe/caffe.vcxproj
@@ -47,6 +47,9 @@
     <PostBuildEvent>
       <Command>"$(ScriptsDir)\FixGFlagsNaming.cmd" "$(OutDir)" $(Configuration)</Command>
     </PostBuildEvent>
+    <ClCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions);CAFFE_VERSION=1.0.0-rc3</PreprocessorDefinitions>
+    </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Link>
@@ -56,6 +59,9 @@
     <PostBuildEvent>
       <Command>"$(ScriptsDir)\FixGFlagsNaming.cmd" "$(OutDir)" $(Configuration)</Command>
     </PostBuildEvent>
+    <ClCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions);CAFFE_VERSION=1.0.0-rc3</PreprocessorDefinitions>
+    </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\tools\caffe.cpp" />

--- a/windows/libcaffe/libcaffe.vcxproj
+++ b/windows/libcaffe/libcaffe.vcxproj
@@ -120,6 +120,7 @@
     <ClCompile Include="..\..\src\caffe\layers\cudnn_tanh_layer.cpp" />
     <ClCompile Include="..\..\src\caffe\layers\data_layer.cpp" />
     <ClCompile Include="..\..\src\caffe\layers\deconv_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\detectnet_transform_layer.cpp" />
     <ClCompile Include="..\..\src\caffe\layers\dropout_layer.cpp" />
     <ClCompile Include="..\..\src\caffe\layers\dummy_data_layer.cpp" />
     <ClCompile Include="..\..\src\caffe\layers\eltwise_layer.cpp" />
@@ -137,6 +138,7 @@
     <ClCompile Include="..\..\src\caffe\layers\infogain_loss_layer.cpp" />
     <ClCompile Include="..\..\src\caffe\layers\inner_product_layer.cpp" />
     <ClCompile Include="..\..\src\caffe\layers\input_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\l1_loss_layer.cpp" />
     <ClCompile Include="..\..\src\caffe\layers\log_layer.cpp" />
     <ClCompile Include="..\..\src\caffe\layers\loss_layer.cpp" />
     <ClCompile Include="..\..\src\caffe\layers\lrn_layer.cpp" />
@@ -182,6 +184,7 @@
     <ClCompile Include="..\..\src\caffe\util\db.cpp" />
     <ClCompile Include="..\..\src\caffe\util\db_leveldb.cpp" />
     <ClCompile Include="..\..\src\caffe\util\db_lmdb.cpp" />
+    <ClCompile Include="..\..\src\caffe\util\detectnet_coverage_rectangular.cpp" />
     <ClCompile Include="..\..\src\caffe\util\hdf5.cpp" />
     <ClCompile Include="..\..\src\caffe\util\im2col.cpp" />
     <ClCompile Include="..\..\src\caffe\util\insert_splits.cpp" />
@@ -222,6 +225,7 @@
     <ClInclude Include="..\..\include\caffe\layers\cudnn_tanh_layer.hpp" />
     <ClInclude Include="..\..\include\caffe\layers\data_layer.hpp" />
     <ClInclude Include="..\..\include\caffe\layers\deconv_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\detectnet_transform_layer.hpp" />
     <ClInclude Include="..\..\include\caffe\layers\dropout_layer.hpp" />
     <ClInclude Include="..\..\include\caffe\layers\dummy_data_layer.hpp" />
     <ClInclude Include="..\..\include\caffe\layers\eltwise_layer.hpp" />
@@ -239,6 +243,7 @@
     <ClInclude Include="..\..\include\caffe\layers\infogain_loss_layer.hpp" />
     <ClInclude Include="..\..\include\caffe\layers\inner_product_layer.hpp" />
     <ClInclude Include="..\..\include\caffe\layers\input_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\l1_loss_layer.hpp" />
     <ClInclude Include="..\..\include\caffe\layers\log_layer.hpp" />
     <ClInclude Include="..\..\include\caffe\layers\loss_layer.hpp" />
     <ClInclude Include="..\..\include\caffe\layers\lrn_layer.hpp" />
@@ -281,6 +286,7 @@
     <ClInclude Include="..\..\include\caffe\util\db.hpp" />
     <ClInclude Include="..\..\include\caffe\util\db_leveldb.hpp" />
     <ClInclude Include="..\..\include\caffe\util\db_lmdb.hpp" />
+    <ClInclude Include="..\..\include\caffe\util\detectnet_coverage.hpp" />
     <ClInclude Include="..\..\include\caffe\util\device_alternate.hpp" />
     <ClInclude Include="..\..\include\caffe\util\hdf5.hpp" />
     <ClInclude Include="..\..\include\caffe\util\im2col.hpp" />

--- a/windows/libcaffe/libcaffe.vcxproj
+++ b/windows/libcaffe/libcaffe.vcxproj
@@ -61,7 +61,7 @@
     </CudaCompile>
     <ClCompile>
       <DisableSpecificWarnings>4661;4005;4812;4715;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-      <AdditionalIncludeDirectories>$(ProjectDir)\..\..\src\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\..\src\;$(ProjectDir)\..\..\3rdparty\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Lib>
       <AdditionalOptions>/ignore:4221 %(AdditionalOptions)</AdditionalOptions>
@@ -84,7 +84,7 @@
     </CudaCompile>
     <ClCompile>
       <DisableSpecificWarnings>4661;4005;4812;4715;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-      <AdditionalIncludeDirectories>$(ProjectDir)\..\..\src\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\..\src\;$(ProjectDir)\..\..\3rdparty\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Lib>
       <AdditionalOptions>/ignore:4221 %(AdditionalOptions)</AdditionalOptions>
@@ -190,6 +190,7 @@
     <ClCompile Include="..\..\src\caffe\util\db_leveldb.cpp" />
     <ClCompile Include="..\..\src\caffe\util\db_lmdb.cpp" />
     <ClCompile Include="..\..\src\caffe\util\detectnet_coverage_rectangular.cpp" />
+    <ClCompile Include="..\..\src\caffe\util\gpu_memory.cpp" />
     <ClCompile Include="..\..\src\caffe\util\hdf5.cpp" />
     <ClCompile Include="..\..\src\caffe\util\im2col.cpp" />
     <ClCompile Include="..\..\src\caffe\util\insert_splits.cpp" />
@@ -295,6 +296,7 @@
     <ClInclude Include="..\..\include\caffe\util\db_lmdb.hpp" />
     <ClInclude Include="..\..\include\caffe\util\detectnet_coverage.hpp" />
     <ClInclude Include="..\..\include\caffe\util\device_alternate.hpp" />
+    <ClInclude Include="..\..\include\caffe\util\gpu_memory.hpp" />
     <ClInclude Include="..\..\include\caffe\util\hdf5.hpp" />
     <ClInclude Include="..\..\include\caffe\util\im2col.hpp" />
     <ClInclude Include="..\..\include\caffe\util\insert_splits.hpp" />
@@ -325,6 +327,7 @@
     <CudaCompile Include="..\..\src\caffe\layers\cudnn_softmax_layer.cu" />
     <CudaCompile Include="..\..\src\caffe\layers\cudnn_tanh_layer.cu" />
     <CudaCompile Include="..\..\src\caffe\layers\deconv_layer.cu" />
+    <CudaCompile Include="..\..\src\caffe\layers\detectnet_transform_layer.cu" />
     <CudaCompile Include="..\..\src\caffe\layers\dropout_layer.cu" />
     <CudaCompile Include="..\..\src\caffe\layers\eltwise_layer.cu" />
     <CudaCompile Include="..\..\src\caffe\layers\elu_layer.cu" />

--- a/windows/libcaffe/libcaffe.vcxproj.filters
+++ b/windows/libcaffe/libcaffe.vcxproj.filters
@@ -336,6 +336,15 @@
     <ClCompile Include="..\..\src\caffe\util\signal_handler.cpp">
       <Filter>src\util</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\caffe\layers\detectnet_transform_layer.cpp">
+      <Filter>src\layers</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\caffe\layers\l1_loss_layer.cpp">
+      <Filter>src\layers</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\caffe\util\detectnet_coverage_rectangular.cpp">
+      <Filter>src\util</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\include\caffe\proto\caffe.pb.h">
@@ -637,6 +646,15 @@
     </ClInclude>
     <ClInclude Include="..\..\include\caffe\layers\scale_layer.hpp">
       <Filter>include\layers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\caffe\layers\detectnet_transform_layer.hpp">
+      <Filter>include\layers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\caffe\layers\l1_loss_layer.hpp">
+      <Filter>include\layers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\caffe\util\detectnet_coverage.hpp">
+      <Filter>include\util</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/windows/libcaffe/libcaffe.vcxproj.filters
+++ b/windows/libcaffe/libcaffe.vcxproj.filters
@@ -1,869 +1,221 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Filter Include="src">
-      <UniqueIdentifier>{253af030-e1e0-426c-9a22-6315b0d2dab7}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="src\util">
-      <UniqueIdentifier>{36c36b62-e801-40f2-bba9-a79f09fa4dba}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="src\layers">
-      <UniqueIdentifier>{66b19093-f1ad-443e-b5d3-f55955ff0ae2}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="include">
-      <UniqueIdentifier>{3be25bf1-cf46-47da-b1ff-30cb442da7c5}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="include\util">
-      <UniqueIdentifier>{9e47fb53-4e3b-4e03-b677-a58cc26af7fb}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="src\proto">
-      <UniqueIdentifier>{bbb6f6f1-8a55-469b-8729-a61f87d6b63d}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="include\proto">
-      <UniqueIdentifier>{f9e33710-c82c-4808-90e7-96620a190b3c}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="cu">
-      <UniqueIdentifier>{9a64cba7-8bef-4df3-b933-adec019daadb}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="cu\layers">
-      <UniqueIdentifier>{96fba2c6-dad0-4766-b354-08a7768d57d8}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="cu\util">
-      <UniqueIdentifier>{e4995612-1b91-40ea-9756-44382eddca40}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="src\solvers">
-      <UniqueIdentifier>{c820c58e-d861-4d88-8b18-2180996d0657}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="include\layers">
-      <UniqueIdentifier>{f10cfd17-81b6-4a08-829d-1a1fa4769d2e}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="cu\solvers">
-      <UniqueIdentifier>{fcb8114c-3425-41da-b30a-af2cb33dd851}</UniqueIdentifier>
-    </Filter>
+    <ClCompile Include="..\..\src\caffe\blob.cpp" />
+    <ClCompile Include="..\..\src\caffe\common.cpp" />
+    <ClCompile Include="..\..\src\caffe\data_reader.cpp" />
+    <ClCompile Include="..\..\src\caffe\data_transformer.cpp" />
+    <ClCompile Include="..\..\src\caffe\internal_thread.cpp" />
+    <ClCompile Include="..\..\src\caffe\layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\absval_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\accuracy_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\argmax_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\base_conv_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\base_data_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\batch_norm_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\batch_reindex_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\bias_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\bnll_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\box_annotator_ohem_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\concat_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\contrastive_loss_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\conv_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\crop_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\cudnn_conv_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\cudnn_lcn_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\cudnn_lrn_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\cudnn_pooling_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\cudnn_relu_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\cudnn_sigmoid_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\cudnn_softmax_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\cudnn_tanh_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\data_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\deconv_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\detectnet_transform_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\dropout_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\dummy_data_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\eltwise_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\elu_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\embed_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\euclidean_loss_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\exp_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\filter_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\flatten_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\hdf5_data_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\hdf5_output_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\hinge_loss_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\im2col_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\image_data_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\infogain_loss_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\inner_product_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\input_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\l1_loss_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\log_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\loss_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\lrn_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\memory_data_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\multinomial_logistic_loss_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\mvn_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\neuron_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\parameter_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\pooling_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\power_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\prelu_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\psroi_pooling_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\reduction_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\relu_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\reshape_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\scale_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\sigmoid_cross_entropy_loss_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\sigmoid_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\silence_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\slice_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\smooth_l1_loss_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\smooth_L1_loss_ohem_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\softmax_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\softmax_loss_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\softmax_loss_ohem_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\split_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\spp_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\tanh_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\threshold_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\tile_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layers\window_data_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\layer_factory.cpp" />
+    <ClCompile Include="..\..\src\caffe\net.cpp" />
+    <ClCompile Include="..\..\src\caffe\parallel.cpp" />
+    <ClCompile Include="..\..\src\caffe\proto\caffe.pb.cc" />
+    <ClCompile Include="..\..\src\caffe\solver.cpp" />
+    <ClCompile Include="..\..\src\caffe\solvers\adadelta_solver.cpp" />
+    <ClCompile Include="..\..\src\caffe\solvers\adagrad_solver.cpp" />
+    <ClCompile Include="..\..\src\caffe\solvers\adam_solver.cpp" />
+    <ClCompile Include="..\..\src\caffe\solvers\nesterov_solver.cpp" />
+    <ClCompile Include="..\..\src\caffe\solvers\rmsprop_solver.cpp" />
+    <ClCompile Include="..\..\src\caffe\solvers\sgd_solver.cpp" />
+    <ClCompile Include="..\..\src\caffe\syncedmem.cpp" />
+    <ClCompile Include="..\..\src\caffe\util\benchmark.cpp" />
+    <ClCompile Include="..\..\src\caffe\util\blocking_queue.cpp" />
+    <ClCompile Include="..\..\src\caffe\util\cudnn.cpp" />
+    <ClCompile Include="..\..\src\caffe\util\db.cpp" />
+    <ClCompile Include="..\..\src\caffe\util\db_leveldb.cpp" />
+    <ClCompile Include="..\..\src\caffe\util\db_lmdb.cpp" />
+    <ClCompile Include="..\..\src\caffe\util\detectnet_coverage_rectangular.cpp" />
+    <ClCompile Include="..\..\src\caffe\util\hdf5.cpp" />
+    <ClCompile Include="..\..\src\caffe\util\im2col.cpp" />
+    <ClCompile Include="..\..\src\caffe\util\insert_splits.cpp" />
+    <ClCompile Include="..\..\src\caffe\util\io.cpp" />
+    <ClCompile Include="..\..\src\caffe\util\math_functions.cpp" />
+    <ClCompile Include="..\..\src\caffe\util\signal_handler.cpp" />
+    <ClCompile Include="..\..\src\caffe\util\upgrade_proto.cpp" />
+    <ClCompile Include="..\..\src\caffe\util\gpu_memory.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\src\caffe\util\im2col.cpp">
-      <Filter>src\util</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\util\insert_splits.cpp">
-      <Filter>src\util</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\util\io.cpp">
-      <Filter>src\util</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\util\math_functions.cpp">
-      <Filter>src\util</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\util\upgrade_proto.cpp">
-      <Filter>src\util</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\util\benchmark.cpp">
-      <Filter>src\util</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\proto\caffe.pb.cc">
-      <Filter>src\proto</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\blob.cpp">
-      <Filter>src</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\common.cpp">
-      <Filter>src</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\data_transformer.cpp">
-      <Filter>src</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\internal_thread.cpp">
-      <Filter>src</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layer_factory.cpp">
-      <Filter>src</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\net.cpp">
-      <Filter>src</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\solver.cpp">
-      <Filter>src</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\syncedmem.cpp">
-      <Filter>src</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\util\db.cpp">
-      <Filter>src\util</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\util\cudnn.cpp">
-      <Filter>src\util</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\util\db_leveldb.cpp">
-      <Filter>src\util</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\util\db_lmdb.cpp">
-      <Filter>src\util</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\util\hdf5.cpp">
-      <Filter>src\util</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layer.cpp">
-      <Filter>src</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\parallel.cpp">
-      <Filter>src</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\data_reader.cpp">
-      <Filter>src</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\util\blocking_queue.cpp">
-      <Filter>src\util</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\solvers\adadelta_solver.cpp">
-      <Filter>src\solvers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\solvers\adagrad_solver.cpp">
-      <Filter>src\solvers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\solvers\adam_solver.cpp">
-      <Filter>src\solvers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\solvers\nesterov_solver.cpp">
-      <Filter>src\solvers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\solvers\rmsprop_solver.cpp">
-      <Filter>src\solvers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\solvers\sgd_solver.cpp">
-      <Filter>src\solvers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\absval_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\accuracy_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\argmax_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\base_conv_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\base_data_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\batch_norm_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\batch_reindex_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\bnll_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\concat_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\contrastive_loss_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\conv_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\crop_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\cudnn_conv_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\cudnn_lcn_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\cudnn_lrn_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\cudnn_pooling_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\cudnn_relu_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\cudnn_sigmoid_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\cudnn_softmax_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\cudnn_tanh_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\data_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\deconv_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\dropout_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\dummy_data_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\eltwise_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\embed_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\euclidean_loss_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\exp_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\filter_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\flatten_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\hdf5_data_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\hdf5_output_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\hinge_loss_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\im2col_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\image_data_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\infogain_loss_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\inner_product_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\input_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\log_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\loss_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\lrn_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\memory_data_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\multinomial_logistic_loss_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\mvn_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\neuron_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\parameter_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\pooling_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\power_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\prelu_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\reduction_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\relu_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\reshape_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\sigmoid_cross_entropy_loss_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\sigmoid_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\silence_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\slice_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\softmax_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\softmax_loss_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\split_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\spp_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\tanh_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\threshold_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\tile_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\window_data_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\bias_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\elu_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\scale_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\util\signal_handler.cpp">
-      <Filter>src\util</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\detectnet_transform_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\l1_loss_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\util\detectnet_coverage_rectangular.cpp">
-      <Filter>src\util</Filter>
-    <ClCompile Include="..\..\src\caffe\layers\psroi_pooling_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\smooth_l1_loss_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\softmax_loss_ohem_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\box_annotator_ohem_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\caffe\layers\smooth_L1_loss_ohem_layer.cpp">
-      <Filter>src\layers</Filter>
-    </ClCompile>
-  </ItemGroup>
-  <ItemGroup>
-    <ClInclude Include="..\..\include\caffe\proto\caffe.pb.h">
-      <Filter>include\proto</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\util\benchmark.hpp">
-      <Filter>include\util</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\util\cudnn.hpp">
-      <Filter>include\util</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\util\device_alternate.hpp">
-      <Filter>include\util</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\util\im2col.hpp">
-      <Filter>include\util</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\util\insert_splits.hpp">
-      <Filter>include\util</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\util\io.hpp">
-      <Filter>include\util</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\util\math_functions.hpp">
-      <Filter>include\util</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\util\mkl_alternate.hpp">
-      <Filter>include\util</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\util\rng.hpp">
-      <Filter>include\util</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\util\upgrade_proto.hpp">
-      <Filter>include\util</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\util\db.hpp">
-      <Filter>include\util</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\util\db_leveldb.hpp">
-      <Filter>include\util</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\util\db_lmdb.hpp">
-      <Filter>include\util</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\util\hdf5.hpp">
-      <Filter>include\util</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\util\blocking_queue.hpp">
-      <Filter>include\util</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\util\signal_handler.h">
-      <Filter>include\util</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\absval_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\accuracy_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\argmax_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\base_conv_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\base_data_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\batch_norm_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\batch_reindex_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\bnll_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\concat_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\contrastive_loss_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\conv_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\crop_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\cudnn_conv_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\cudnn_lcn_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\cudnn_lrn_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\cudnn_pooling_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\cudnn_relu_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\cudnn_sigmoid_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\cudnn_softmax_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\cudnn_tanh_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\data_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\deconv_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\dropout_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\dummy_data_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\eltwise_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\embed_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\euclidean_loss_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\exp_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\filter_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\flatten_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\hdf5_data_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\hdf5_output_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\hinge_loss_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\im2col_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\image_data_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\infogain_loss_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\inner_product_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\input_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\log_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\loss_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\lrn_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\memory_data_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\multinomial_logistic_loss_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\mvn_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\neuron_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\parameter_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\pooling_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\power_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\prelu_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\python_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\reduction_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\relu_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\reshape_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\sigmoid_cross_entropy_loss_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\sigmoid_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\silence_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\slice_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\softmax_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\softmax_loss_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\split_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\spp_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\tanh_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\threshold_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\tile_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\window_data_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\blob.hpp">
-      <Filter>include</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\caffe.hpp">
-      <Filter>include</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\common.hpp">
-      <Filter>include</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\data_reader.hpp">
-      <Filter>include</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\data_transformer.hpp">
-      <Filter>include</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\filler.hpp">
-      <Filter>include</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\internal_thread.hpp">
-      <Filter>include</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layer.hpp">
-      <Filter>include</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layer_factory.hpp">
-      <Filter>include</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\net.hpp">
-      <Filter>include</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\parallel.hpp">
-      <Filter>include</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\sgd_solvers.hpp">
-      <Filter>include</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\solver.hpp">
-      <Filter>include</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\solver_factory.hpp">
-      <Filter>include</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\syncedmem.hpp">
-      <Filter>include</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\bias_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\elu_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\scale_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\detectnet_transform_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\l1_loss_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\util\detectnet_coverage.hpp">
-      <Filter>include\util</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\psroi_pooling_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\caffe\layers\smooth_l1_loss_layer.hpp">
-      <Filter>include\layers</Filter>
-    </ClInclude>
-  </ItemGroup>
-  <ItemGroup>
-    <CudaCompile Include="..\..\src\caffe\layers\contrastive_loss_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\euclidean_loss_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\sigmoid_cross_entropy_loss_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\softmax_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\softmax_loss_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\absval_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\bnll_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\cudnn_relu_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\cudnn_sigmoid_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\cudnn_softmax_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\cudnn_tanh_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\dropout_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\power_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\relu_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\sigmoid_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\tanh_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\threshold_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\concat_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\eltwise_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\inner_product_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\lrn_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\mvn_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\silence_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\slice_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\split_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\base_data_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\hdf5_data_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\hdf5_output_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\util\im2col.cu">
-      <Filter>cu\util</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\util\math_functions.cu">
-      <Filter>cu\util</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\reduction_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\prelu_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\deconv_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\im2col_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\conv_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\crop_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\batch_norm_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\batch_reindex_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\cudnn_conv_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\cudnn_lcn_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\cudnn_lrn_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\cudnn_pooling_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\pooling_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\exp_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\filter_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\log_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\tile_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\embed_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\bias_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\elu_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\scale_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\solvers\adadelta_solver.cu">
-      <Filter>cu\solvers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\solvers\adagrad_solver.cu">
-      <Filter>cu\solvers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\solvers\adam_solver.cu">
-      <Filter>cu\solvers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\solvers\nesterov_solver.cu">
-      <Filter>cu\solvers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\solvers\rmsprop_solver.cu">
-      <Filter>cu\solvers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\solvers\sgd_solver.cu">
-      <Filter>cu\solvers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\psroi_pooling_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\smooth_l1_loss_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\softmax_loss_ohem_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\box_annotator_ohem_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
-    <CudaCompile Include="..\..\src\caffe\layers\smooth_L1_loss_ohem_layer.cu">
-      <Filter>cu\layers</Filter>
-    </CudaCompile>
+    <ClInclude Include="..\..\include\caffe\blob.hpp" />
+    <ClInclude Include="..\..\include\caffe\caffe.hpp" />
+    <ClInclude Include="..\..\include\caffe\common.hpp" />
+    <ClInclude Include="..\..\include\caffe\data_reader.hpp" />
+    <ClInclude Include="..\..\include\caffe\data_transformer.hpp" />
+    <ClInclude Include="..\..\include\caffe\filler.hpp" />
+    <ClInclude Include="..\..\include\caffe\internal_thread.hpp" />
+    <ClInclude Include="..\..\include\caffe\layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\absval_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\accuracy_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\argmax_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\base_conv_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\base_data_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\batch_norm_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\batch_reindex_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\bias_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\bnll_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\concat_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\contrastive_loss_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\conv_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\crop_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\cudnn_conv_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\cudnn_lcn_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\cudnn_lrn_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\cudnn_pooling_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\cudnn_relu_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\cudnn_sigmoid_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\cudnn_softmax_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\cudnn_tanh_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\data_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\deconv_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\detectnet_transform_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\dropout_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\dummy_data_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\eltwise_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\elu_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\embed_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\euclidean_loss_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\exp_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\filter_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\flatten_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\hdf5_data_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\hdf5_output_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\hinge_loss_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\im2col_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\image_data_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\infogain_loss_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\inner_product_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\input_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\l1_loss_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\log_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\loss_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\lrn_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\memory_data_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\multinomial_logistic_loss_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\mvn_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\neuron_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\parameter_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\pooling_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\power_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\prelu_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\psroi_pooling_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\python_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\reduction_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\relu_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\reshape_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\scale_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\sigmoid_cross_entropy_loss_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\sigmoid_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\silence_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\slice_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\smooth_l1_loss_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\softmax_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\softmax_loss_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\split_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\spp_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\tanh_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\threshold_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\tile_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layers\window_data_layer.hpp" />
+    <ClInclude Include="..\..\include\caffe\layer_factory.hpp" />
+    <ClInclude Include="..\..\include\caffe\net.hpp" />
+    <ClInclude Include="..\..\include\caffe\parallel.hpp" />
+    <ClInclude Include="..\..\include\caffe\proto\caffe.pb.h" />
+    <ClInclude Include="..\..\include\caffe\sgd_solvers.hpp" />
+    <ClInclude Include="..\..\include\caffe\solver.hpp" />
+    <ClInclude Include="..\..\include\caffe\solver_factory.hpp" />
+    <ClInclude Include="..\..\include\caffe\syncedmem.hpp" />
+    <ClInclude Include="..\..\include\caffe\util\benchmark.hpp" />
+    <ClInclude Include="..\..\include\caffe\util\blocking_queue.hpp" />
+    <ClInclude Include="..\..\include\caffe\util\cudnn.hpp" />
+    <ClInclude Include="..\..\include\caffe\util\db.hpp" />
+    <ClInclude Include="..\..\include\caffe\util\db_leveldb.hpp" />
+    <ClInclude Include="..\..\include\caffe\util\db_lmdb.hpp" />
+    <ClInclude Include="..\..\include\caffe\util\detectnet_coverage.hpp" />
+    <ClInclude Include="..\..\include\caffe\util\device_alternate.hpp" />
+    <ClInclude Include="..\..\include\caffe\util\hdf5.hpp" />
+    <ClInclude Include="..\..\include\caffe\util\im2col.hpp" />
+    <ClInclude Include="..\..\include\caffe\util\insert_splits.hpp" />
+    <ClInclude Include="..\..\include\caffe\util\io.hpp" />
+    <ClInclude Include="..\..\include\caffe\util\math_functions.hpp" />
+    <ClInclude Include="..\..\include\caffe\util\mkl_alternate.hpp" />
+    <ClInclude Include="..\..\include\caffe\util\rng.hpp" />
+    <ClInclude Include="..\..\include\caffe\util\signal_handler.h" />
+    <ClInclude Include="..\..\include\caffe\util\upgrade_proto.hpp" />
+    <ClInclude Include="..\..\include\caffe\util\gpu_memory.hpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/windows/matcaffe/matcaffe.vcxproj
+++ b/windows/matcaffe/matcaffe.vcxproj
@@ -45,6 +45,8 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <DisableSpecificWarnings>4003</DisableSpecificWarnings>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">_DEBUG;%(PreprocessorDefinitions);CAFFE_VERSION=1.0.0-rc3</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NDEBUG;%(PreprocessorDefinitions);CAFFE_VERSION=1.0.0-rc3</PreprocessorDefinitions>
     </ClCompile>
     <PreBuildEvent>
       <Command>"$(ScriptsDir)\MatlabPreBuild.cmd" "$(SolutionDir)" "$(OutDir)"</Command>

--- a/windows/pycaffe/pycaffe.vcxproj
+++ b/windows/pycaffe/pycaffe.vcxproj
@@ -49,6 +49,8 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <DisableSpecificWarnings>4003</DisableSpecificWarnings>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NDEBUG;%(PreprocessorDefinitions);CAFFE_VERSION=1.0.0-rc3</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">_DEBUG;%(PreprocessorDefinitions);CAFFE_VERSION=1.0.0-rc3</PreprocessorDefinitions>
     </ClCompile>
     <PreBuildEvent>
       <Command>"$(ScriptsDir)\PythonPreBuild.cmd" "$(SolutionDir)" "$(ProtocDir)" "$(OutDir)"</Command>

--- a/windows/scripts/PythonPostBuild.cmd
+++ b/windows/scripts/PythonPostBuild.cmd
@@ -3,6 +3,8 @@ set OUTPUT_DIR=%~2%
 
 echo PythonPostBuild.cmd : copy python generated scripts to output.
 
+copy /y "%SOLUTION_DIR%..\python\caffe\layers\detectnet\*.py" "%OUTPUT_DIR%pycaffe\caffe\layers\detectnet"
+copy /y "%SOLUTION_DIR%..\python\caffe\layers\*.py" "%OUTPUT_DIR%pycaffe\caffe\layers"
 copy /y "%SOLUTION_DIR%..\python\caffe\*.py" "%OUTPUT_DIR%pycaffe\caffe"
 copy /y "%SOLUTION_DIR%..\python\*.py" "%OUTPUT_DIR%pycaffe"
 move /y "%OUTPUT_DIR%_caffe.*" "%OUTPUT_DIR%pycaffe\caffe"

--- a/windows/scripts/PythonPreBuild.cmd
+++ b/windows/scripts/PythonPreBuild.cmd
@@ -7,9 +7,13 @@ echo PythonPreBuild.cmd : Create output directories for python scripts.
 if not exist "%OUTPUT_DIR%\pycaffe" mkdir "%OUTPUT_DIR%\pycaffe"
 if not exist "%OUTPUT_DIR%\pycaffe\caffe" mkdir "%OUTPUT_DIR%\pycaffe\caffe"
 if not exist "%OUTPUT_DIR%\pycaffe\caffe\proto" mkdir "%OUTPUT_DIR%\pycaffe\caffe\proto"
+if not exist "%OUTPUT_DIR%\pycaffe\caffe\layers" mkdir "%OUTPUT_DIR%\pycaffe\caffe\layers"
+if not exist "%OUTPUT_DIR%\pycaffe\caffe\layers\detectnet" mkdir "%OUTPUT_DIR%\pycaffe\caffe\layers\detectnet"
 
 echo PythonPreBuild.cmd : Create dummy __init__.py file
 rem. > "%OUTPUT_DIR%\pycaffe\caffe\proto\__init__.py"
+rem. > "%OUTPUT_DIR%\pycaffe\caffe\layers\__init__.py"
+rem. > "%OUTPUT_DIR%\pycaffe\caffe\layers\detectnet\__init__.py"
 
 echo PythonPreBuild.cmd : Generating src\caffe\proto\caffe.pb.h with python bindings
 "%PROTO_COMPILER_DIR%\protoc" "%SOLUTION_DIR%\..\src\caffe\proto\caffe.proto" --proto_path="%SOLUTION_DIR%\..\src\caffe\proto" --python_out="%OUTPUT_DIR%\pycaffe\caffe\proto"

--- a/windows/test_all/test_all.vcxproj
+++ b/windows/test_all/test_all.vcxproj
@@ -90,6 +90,7 @@
     <ClCompile Include="..\..\src\caffe\test\test_data_transformer.cpp" />
     <ClCompile Include="..\..\src\caffe\test\test_db.cpp" />
     <ClCompile Include="..\..\src\caffe\test\test_deconvolution_layer.cpp" />
+    <ClCompile Include="..\..\src\caffe\test\test_detectnet_transform.cpp" />
     <ClCompile Include="..\..\src\caffe\test\test_dummy_data_layer.cpp" />
     <ClCompile Include="..\..\src\caffe\test\test_eltwise_layer.cpp" />
     <ClCompile Include="..\..\src\caffe\test\test_embed_layer.cpp" />

--- a/windows/test_all/test_all.vcxproj.filters
+++ b/windows/test_all/test_all.vcxproj.filters
@@ -215,6 +215,9 @@
     <ClCompile Include="..\..\src\caffe\test\test_scale_layer.cpp">
       <Filter>src</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\caffe\test\test_detectnet_transform.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\include\caffe\test\test_caffe_main.hpp">
@@ -226,10 +229,5 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <CudaCompile Include="..\..\src\caffe\test\test_im2col_kernel.cu">
-      <Filter>cu</Filter>
-    </CudaCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This pull request includes two new layers, "L1Loss" and "DetectnetTransformation", which are already included in NVIDIA's Caffe fork (https://github.com/NVIDIA/caffe). These layers are used in NVIDIA's DIGITS (https://github.com/NVIDIA/DIGITS) for object detection (https://github.com/NVIDIA/DIGITS/tree/master/examples/object-detection) and image segmentation (https://github.com/NVIDIA/DIGITS/tree/master/examples/segmentation).

Besides, as DIGITS needs to verify the Caffe version from the CAFFE_VERSION variable (otherwise it doesn't work), and the current Windows version of Caffe doesn't define it (it is included in CMakeLists.txt of the root folder, but not in any Visual Studio project), this pull request also includes it in the "preprocessor definitions" of the following Visual Studio projects, which use this variable too: caffe, pycaffe and matcaffe.
