### PR TITLE
Fix windows build in appveyor by disabling parallel build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,9 +10,9 @@ build_script:
 
     set PATH=%PATH:nuget=hello%
 
-    msbuild Caffe.sln /m /v:m /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /p:Configuration=Debug;CpuOnlyBuild=true;UseCuDNN=false
+    msbuild Caffe.sln /v:m /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /p:Configuration=Debug;CpuOnlyBuild=true;UseCuDNN=false
 
-    msbuild Caffe.sln /m /v:m /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /p:Configuration=Release;CpuOnlyBuild=true;UseCuDNN=false;WholeProgramOptimization=false
+    msbuild Caffe.sln /v:m /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /p:Configuration=Release;CpuOnlyBuild=true;UseCuDNN=false;WholeProgramOptimization=false
 
     cd ..
 

--- a/windows/nuget.config
+++ b/windows/nuget.config
@@ -3,5 +3,7 @@
   <packageSources>
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
   </packageSources>
-  <repositoryPath>..\..\NugetPackages</repositoryPath>
+  <config>
+    <add key="repositoryPath" value="..\..\NugetPackages" />
+  </config>
 </configuration>


### PR DESCRIPTION
Fix windows build in appveyor by disabling parallel build
Enables correct auto package restore in visual studio by fixing the nuget.config