### PR TITLE
modify matlab include path in "CommonSettings.props" file

### DIFF
--- a/windows/CommonSettings.props.example
+++ b/windows/CommonSettings.props.example
@@ -52,7 +52,7 @@
     <PropertyGroup Condition="'$(MatlabSupport)'=='true'">
         <MatlabDir>C:\Program Files\MATLAB\R2014b</MatlabDir>
         <LibraryPath>$(MatlabDir)\extern\lib\win64\microsoft;$(LibraryPath)</LibraryPath>
-        <IncludePath>$(MatlabDir)\extern\include;$(IncludePath)</IncludePath>
+        <IncludePath>$(MatlabDir)\extern\include;$(MatlabDir)\toolbox\distcomp\gpu\extern\include;$(IncludePath)</IncludePath>
     </PropertyGroup>
     <ItemDefinitionGroup Condition="'$(CpuOnlyBuild)'=='true'">
         <ClCompile>


### PR DESCRIPTION
when i use vs2013 compile matcaffe project, the IDE have an error that show it can not find "mxGPUArray.h" file